### PR TITLE
fixes #22, icons autohide with expected behavior

### DIFF
--- a/hidden/ViewControlllers/StatusBarController.swift
+++ b/hidden/ViewControlllers/StatusBarController.swift
@@ -53,6 +53,7 @@ class StatusBarController{
         {
             setupCollapseMenuBar()
         }
+        autoCollapseIfNeeded()
     }
     
     private func isValidPosition() -> Bool {
@@ -82,10 +83,9 @@ class StatusBarController{
     }
     
     private func autoCollapseIfNeeded() {
-        let isExpanded = Util.getIsCollapse()
         let isAutoHide = Util.getIsAutoHide()
 
-        if isExpanded || isAutoHide == false {return}
+        if isAutoHide == false {return}
         
         startTimerToAutoHide()
     }


### PR DESCRIPTION
#### What's this PR do?

- [x] Icons will autohide after 5 seconds on open if autohide is true


Notes:
1. Removed `isExpanded` check in `if` statement, it's always `true` on app open so the return is executed.
2. Added call to `autoCollapseIfNeeded` after setting up menu bar.
#### What are the relevant Git tickets?

https://github.com/dwarvesf/hidden/issues/22

#### Steps to reproduce:
1. Open Hidden bar the first time
2. Choose option auto-hide after 5s
3. Quit Hidden Bar
4. Reopen
5. Auto-hide icon after 5s 

Tested on macOS, 10.15.1


edit:
I don't do many PRs, will create new branches for separate fixes in the future.