### PR TITLE
Avoid preferences window deactivate when unchecking "Keep Icon in Dock"

### DIFF
--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -86,6 +86,7 @@ class PreferencesViewController: NSViewController {
         case .off:
             Util.setIsKeepInDock(false)
             let _ = Util.toggleDockIcon(false)
+            Util.showPrefWindow() // avoid window deactivate
         default:
             print("")
         }


### PR DESCRIPTION
**Bugfix: Avoid preferences window deactivate when unchecking "Keep Icon in Dock"**

#### What's this PR do?

In the previous version of Hidden Bar, if the user unchecks "Keep Icon in Dock", the preferences window will disappear. This PR solved this issue.