### PR TITLE
Persist status item positions

### DIFF
--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -39,6 +39,7 @@ class StatusBarController {
     
     //MARK: - Methods
     init() {
+        
         setupUI()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
@@ -60,6 +61,9 @@ class StatusBarController {
             button.target = self
             button.action = #selector(expandCollapseIfNeeded(_:))
         }
+        
+        expandCollapseStatusBar.autosaveName = "hiddenbar_expandcollapse";
+        separateStatusBar.autosaveName = "hiddenbar_separate";
     }
     
     @objc func expandCollapseIfNeeded(_ sender: NSStatusBarButton?) {


### PR DESCRIPTION
#### What's this PR do?

- [x] Persist status item icon positions across app restarts

#### What are the relevant Git tickets?

#### Screenshots (if appropriate)

#### Any background context you want to provide? (if appropriate)

- This might be a new behavior as of macOS Big Sur developer beta, but upon restarting the app, the separator and expand/collapse status bar item goes to the left-most position, discarding any customization done to their positions. This PR should fix that.
