### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Hidden Bar is notarized before distributed out side App Store. It's safe to 
 #### Using Homebrew
 
 ```
-brew cask install hiddenbar
+brew install --cask hiddenbar
 ```
 
 #### Manual download


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103124095-efc57c80-46c9-11eb-8468-437ee749f860.png)

