### PR TITLE
Update brew command to use --cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Hidden Bar is notarized before distributed out side App Store. It's safe to 
 #### Using Homebrew
 
 ```
-brew cask install hiddenbar
+brew install --cask hiddenbar
 ```
 
 #### Manual download


### PR DESCRIPTION
This change updates the Homebrew installation command in the README, per the new command format in Homebrew.

Running `brew cask install hiddenbar` in Homebrew 2.7.1 shows the following error:

```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

This PR changes the command to `brew install --cask hiddenbar` which wotks.
