### PR TITLE
Support RTL Languages

### DIFF
--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00117C4426600671005E517C /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00117C4326600671005E517C /* Assets.swift */; };
 		00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */; };
 		0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */; };
 		08A5F85A23AA007A00981CA5 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */; };
@@ -56,6 +57,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00117C4326600671005E517C /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeybindingPreferences.swift; sourceTree = "<group>"; };
 		08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				92C97B87220032ED0007559C /* Util.swift */,
+				00117C4326600671005E517C /* Assets.swift */,
 				92C97B8E220147FE0007559C /* Constant.swift */,
 				08A5F86023AA085B00981CA5 /* Preferences.swift */,
 			);
@@ -393,6 +396,7 @@
 				08C20FDE23AABDD10035D978 /* HyperlinkTextField.swift in Sources */,
 				92C97B88220032ED0007559C /* Util.swift in Sources */,
 				967F4B2524169BC800F18D3C /* String+Extension.swift in Sources */,
+				00117C4426600671005E517C /* Assets.swift in Sources */,
 				08A5F85A23AA007A00981CA5 /* PreferencesViewController.swift in Sources */,
 				3CF14C82221FA49D0083D42B /* PreferencesWindowController.swift in Sources */,
 				92C97B8B220049D20007559C /* NSBarButtonItem+Extension.swift in Sources */,
@@ -581,7 +585,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 11;
-				DEVELOPMENT_TEAM = W777S7V8TN;
+				DEVELOPMENT_TEAM = VGURA84Q2L;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = hidden/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -606,7 +610,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 11;
-				DEVELOPMENT_TEAM = W777S7V8TN;
+				DEVELOPMENT_TEAM = VGURA84Q2L;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = hidden/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -630,7 +634,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = W777S7V8TN;
+				DEVELOPMENT_TEAM = VGURA84Q2L;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = LauncherApplication/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         registerDefaultValues()
         setupHotKey()
         openPreferencesIfNeeded()
+        detectLTRLang()
     }
     
     func openPreferencesIfNeeded() {
@@ -65,5 +66,11 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         return true
     }
     
+    func detectLTRLang() {
+        // Languages like Arabic uses right to left (RTL) writing direction,
+        // so some behavier of the app needs to be changed in these cases
+        
+        Constant.isUsingLTRLanguage = (NSApplication.shared.userInterfaceLayoutDirection == .leftToRight)
+    }
    
 }

--- a/hidden/Base.lproj/Main.storyboard
+++ b/hidden/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -1094,7 +1094,7 @@ between sections to configure Hidden Bar.</string>
                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="seprated" id="AWD-J8-gJn"/>
                                                     <color key="contentTintColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 </imageView>
-                                                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jj7-ce-RFp">
+                                                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" mirrorLayoutDirectionWhenInternationalizing="always" translatesAutoresizingMaskIntoConstraints="NO" id="Jj7-ce-RFp">
                                                     <rect key="frame" x="132" y="3" width="16" height="16"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="16" id="4MO-Ka-D1V"/>

--- a/hidden/Common/Assets.swift
+++ b/hidden/Common/Assets.swift
@@ -1,0 +1,26 @@
+//
+//  Assets.swift
+//  Hidden Bar
+//
+//  Created by Peter Luo on 2021/5/28.
+//  Copyright © 2021 Dwarves Foundation. All rights reserved.
+//
+
+import AppKit
+
+struct Assets {
+    static var expandImage: NSImage? {
+        if (Constant.isUsingLTRLanguage) {
+            return NSImage(named: NSImage.Name("ic_expand"))
+        } else {
+            return NSImage(named: NSImage.Name("ic_collapse"))
+        }
+    }
+    static var collapseImage: NSImage? {
+        if (Constant.isUsingLTRLanguage) {
+            return NSImage(named: NSImage.Name("ic_collapse"))
+        } else {
+            return NSImage(named: NSImage.Name("ic_expand"))
+        }
+    }
+}

--- a/hidden/Common/Constant.swift
+++ b/hidden/Common/Constant.swift
@@ -11,4 +11,6 @@ import Foundation
 enum Constant {
     static let appName = "Hidden Bar"
     static let launcherAppId = "com.dwarvesv.LauncherApplication"
+    
+    static var isUsingLTRLanguage = false
 }

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -26,8 +26,6 @@ class StatusBarController {
     private let collapseTerminateStatusBarIconLength: CGFloat = Preferences.alwaysHiddenSectionEnabled ? 10000 : 0
     
     private let imgIconLine = NSImage(named:NSImage.Name("ic_line"))
-    private let imgIconCollapse = NSImage(named:NSImage.Name("ic_collapse"))
-    private let imgIconExpand = NSImage(named:NSImage.Name("ic_expand"))
     
     private var isCollapsed: Bool {
         return self.separateStatusBar.length == self.collapseSeparateStatusBarIconLength
@@ -39,7 +37,11 @@ class StatusBarController {
             let separateBarButtonX = self.separateStatusBar.button?.getOrigin?.x
             else {return false}
         
-        return expandBarButtonX >= separateBarButtonX
+        if Constant.isUsingLTRLanguage {
+            return expandBarButtonX >= separateBarButtonX
+        } else {
+            return expandBarButtonX <= separateBarButtonX
+        }
     }
     private var isValidTogglablePosition: Bool {
         if !Preferences.alwaysHiddenSectionEnabled { return true }
@@ -48,8 +50,12 @@ class StatusBarController {
             let separateBarButtonX = self.separateStatusBar.button?.getOrigin?.x,
             let terminateBarButtonX = self.alwayHideSeparateStatusBar?.button?.getOrigin?.x
             else {return false}
-            
-        return separateBarButtonX >= terminateBarButtonX
+        
+        if Constant.isUsingLTRLanguage {
+            return separateBarButtonX >= terminateBarButtonX
+        } else {
+            return separateBarButtonX <= terminateBarButtonX
+        }
     }
     
     //MARK: - Methods
@@ -75,7 +81,7 @@ class StatusBarController {
         updateAutoCollapseMenuTitle()
         
         if let button = expandCollapseStatusBar.button {
-            button.image = self.imgIconCollapse
+            button.image = Assets.collapseImage
             button.target = self
             
             button.action = #selector(self.expandCollapseButtonPressed(sender:))
@@ -137,7 +143,7 @@ class StatusBarController {
         
         separateStatusBar.length = self.collapseSeparateStatusBarIconLength
         if let button = expandCollapseStatusBar.button {
-            button.image = self.imgIconExpand
+            button.image = Assets.expandImage
         }
 
     }
@@ -146,7 +152,7 @@ class StatusBarController {
         guard self.isCollapsed else {return}
         separateStatusBar.length = normalSeparateStatusBarIconLength
         if let button = expandCollapseStatusBar.button {
-            button.image = self.imgIconCollapse
+            button.image = Assets.collapseImage
         }
         autoCollapseIfNeeded()
     }


### PR DESCRIPTION
#### What's this PR do?
Previously the app stops working when macOS's primary language is set to right-to-left languages (such as Arabic).

##### Changes in this PR includes:
- Reversed the expand/collapse icon in the status bar and the banner
- Changed valid position check in RTL languages

#### What are the relevant Git tickets?
#103 The Application doesn't work properly if Mac OS locale is right-to-left (rtl)
#131 Swap condition for RTL languages

#### Any background context you want to provide? (if appropriate)
How to test this feature (For LTR language users):
Unfortunately you have to switch your system languages to Arabic (or other RTL language) to test this feature. Unlike most cases, you can't just set the language to pseudo right-to-left language in the build scheme, because the status bar would still be on the right side of the app menu.