### PR TITLE
Feature: automatically expand collapse when mouse hovers on the menu bar

### DIFF
--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Dwarves Foundation";
 				TargetAttributes = {
 					929113F021F9D04100173149 = {

--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0095D59A2664E5EE00D4E607 /* EventMoniter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D5992664E5EE00D4E607 /* EventMoniter.swift */; };
 		0095D59C2664E8C900D4E607 /* MouseOverDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D59B2664E8C900D4E607 /* MouseOverDetector.swift */; };
 		0095D59E2664EDB000D4E607 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D59D2664EDB000D4E607 /* WindowInfo.swift */; };
+		0095D5A02664F7F800D4E607 /* CGPoint+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D59F2664F7F800D4E607 /* CGPoint+Extension.swift */; };
 		0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */; };
 		08A5F85A23AA007A00981CA5 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */; };
 		08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85B23AA013100981CA5 /* SelectedSecond.swift */; };
@@ -65,6 +66,7 @@
 		0095D5992664E5EE00D4E607 /* EventMoniter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMoniter.swift; sourceTree = "<group>"; };
 		0095D59B2664E8C900D4E607 /* MouseOverDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseOverDetector.swift; sourceTree = "<group>"; };
 		0095D59D2664EDB000D4E607 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
+		0095D59F2664F7F800D4E607 /* CGPoint+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPoint+Extension.swift"; sourceTree = "<group>"; };
 		0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeybindingPreferences.swift; sourceTree = "<group>"; };
 		08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		08A5F85B23AA013100981CA5 /* SelectedSecond.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSecond.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */,
 				55F3F1182608923B0054B881 /* Date+Extension.swift */,
 				55F3F11C2608925A0054B881 /* StackView+Extension.swift */,
+				0095D59F2664F7F800D4E607 /* CGPoint+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -427,6 +430,7 @@
 				92C97B8D220058740007559C /* NSView+Extension.swift in Sources */,
 				0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */,
 				55F3F11D2608925A0054B881 /* StackView+Extension.swift in Sources */,
+				0095D5A02664F7F800D4E607 /* CGPoint+Extension.swift in Sources */,
 				08C20FE223AB452C0035D978 /* AboutViewController.swift in Sources */,
 				00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */,
 				08A5F86423AA09F300981CA5 /* UserDefault+Extension.swift in Sources */,

--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		00117C4426600671005E517C /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00117C4326600671005E517C /* Assets.swift */; };
 		00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */; };
+		0095D59A2664E5EE00D4E607 /* EventMoniter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D5992664E5EE00D4E607 /* EventMoniter.swift */; };
+		0095D59C2664E8C900D4E607 /* MouseOverDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D59B2664E8C900D4E607 /* MouseOverDetector.swift */; };
+		0095D59E2664EDB000D4E607 /* WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095D59D2664EDB000D4E607 /* WindowInfo.swift */; };
 		0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */; };
 		08A5F85A23AA007A00981CA5 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */; };
 		08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85B23AA013100981CA5 /* SelectedSecond.swift */; };
@@ -59,6 +62,9 @@
 /* Begin PBXFileReference section */
 		00117C4326600671005E517C /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
+		0095D5992664E5EE00D4E607 /* EventMoniter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMoniter.swift; sourceTree = "<group>"; };
+		0095D59B2664E8C900D4E607 /* MouseOverDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseOverDetector.swift; sourceTree = "<group>"; };
+		0095D59D2664EDB000D4E607 /* WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInfo.swift; sourceTree = "<group>"; };
 		0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeybindingPreferences.swift; sourceTree = "<group>"; };
 		08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		08A5F85B23AA013100981CA5 /* SelectedSecond.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSecond.swift; sourceTree = "<group>"; };
@@ -141,6 +147,8 @@
 			children = (
 				0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */,
 				08A5F85B23AA013100981CA5 /* SelectedSecond.swift */,
+				0095D5992664E5EE00D4E607 /* EventMoniter.swift */,
+				0095D59D2664EDB000D4E607 /* WindowInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -159,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				92C97B9022018C1F0007559C /* StatusBarController.swift */,
+				0095D59B2664E8C900D4E607 /* MouseOverDetector.swift */,
 			);
 			path = StatusBar;
 			sourceTree = "<group>";
@@ -398,10 +407,12 @@
 			files = (
 				92C97B8F220147FE0007559C /* Constant.swift in Sources */,
 				08C20FE023AB44E60035D978 /* Bundle+Extension.swift in Sources */,
+				0095D59E2664EDB000D4E607 /* WindowInfo.swift in Sources */,
 				08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */,
 				08A5F86123AA085B00981CA5 /* Preferences.swift in Sources */,
 				92C97B9122018C1F0007559C /* StatusBarController.swift in Sources */,
 				55F3F1192608923B0054B881 /* Date+Extension.swift in Sources */,
+				0095D59C2664E8C900D4E607 /* MouseOverDetector.swift in Sources */,
 				92D2122221FEE06600C92FF4 /* LauncherApplication.app in Sources */,
 				08B9F32C2411883300AA0551 /* NSWindow+Extension.swift in Sources */,
 				929113F521F9D04100173149 /* AppDelegate.swift in Sources */,
@@ -409,6 +420,7 @@
 				92C97B88220032ED0007559C /* Util.swift in Sources */,
 				967F4B2524169BC800F18D3C /* String+Extension.swift in Sources */,
 				00117C4426600671005E517C /* Assets.swift in Sources */,
+				0095D59A2664E5EE00D4E607 /* EventMoniter.swift in Sources */,
 				08A5F85A23AA007A00981CA5 /* PreferencesViewController.swift in Sources */,
 				3CF14C82221FA49D0083D42B /* PreferencesWindowController.swift in Sources */,
 				92C97B8B220049D20007559C /* NSBarButtonItem+Extension.swift in Sources */,

--- a/Hidden Bar.xcodeproj/xcshareddata/xcschemes/Hidden Bar.xcscheme
+++ b/Hidden Bar.xcodeproj/xcshareddata/xcschemes/Hidden Bar.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Hidden Bar.xcodeproj/xcshareddata/xcschemes/LauncherApplication.xcscheme
+++ b/Hidden Bar.xcodeproj/xcshareddata/xcschemes/LauncherApplication.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -71,7 +71,7 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         // Languages like Arabic uses right to left (RTL) writing direction,
         // so some behavier of the app needs to be changed in these cases
         
-        Constant.isUsingLTRLanguage = (NSApplication.shared.userInterfaceLayoutDirection == .leftToRight)
+        Util.SharedValues.isUsingLTRLanguage = (NSApplication.shared.userInterfaceLayoutDirection == .leftToRight)
     }
    
 }

--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -47,6 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate{
          UserDefaults.standard.register(defaults: [
             UserDefaults.Key.isAutoStart: false,
             UserDefaults.Key.isShowPreference: true,
+            UserDefaults.Key.autoExpandCollapse: false,
             UserDefaults.Key.isAutoHide: true,
             UserDefaults.Key.numberOfSecondForAutoHide: 10.0,
             UserDefaults.Key.areSeparatorsHidden: false,

--- a/hidden/Base.lproj/Main.storyboard
+++ b/hidden/Base.lproj/Main.storyboard
@@ -83,7 +83,7 @@
                                 <toolbarItem implicitItemIdentifier="0B8CB0BB-7947-4D4F-8C91-449CFFCEC98B" label="Custom View" paletteLabel="Custom View" sizingBehavior="auto" id="ML6-W4-U8X">
                                     <nil key="toolTip"/>
                                     <textField key="view" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="3wq-bO-RJi">
-                                        <rect key="frame" x="10" y="14" width="56" height="16"/>
+                                        <rect key="frame" x="12" y="14" width="52" height="16"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="General" id="zAf-vj-OOZ">
                                             <font key="font" usesAppearanceFont="YES"/>
@@ -97,7 +97,7 @@
                                 <toolbarItem implicitItemIdentifier="F7DA19CF-BC58-47E1-8140-D04939EE4CA7" label="Custom View" paletteLabel="Custom View" sizingBehavior="auto" id="NIO-JJ-pjq">
                                     <nil key="toolTip"/>
                                     <segmentedControl key="view" verticalHuggingPriority="750" id="wAJ-zO-0Lg">
-                                        <rect key="frame" x="0.0" y="14" width="145" height="23"/>
+                                        <rect key="frame" x="0.0" y="14" width="120" height="23"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="texturedSquare" trackingMode="selectOne" id="B2x-1Q-Aei">
                                             <font key="font" metaFont="system"/>

--- a/hidden/Base.lproj/Main.storyboard
+++ b/hidden/Base.lproj/Main.storyboard
@@ -413,17 +413,17 @@
             <objects>
                 <viewController storyboardIdentifier="prefVC" showSeguePresentationStyle="single" id="XfG-lQ-9wD" customClass="PreferencesViewController" customModule="Hidden_Bar" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="613" height="481"/>
+                        <rect key="frame" x="0.0" y="0.0" width="689" height="481"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <box autoresizesSubviews="NO" boxType="custom" borderType="none" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="Jjd-1G-63n">
-                                <rect key="frame" x="0.0" y="215" width="613" height="266"/>
+                                <rect key="frame" x="0.0" y="241" width="689" height="240"/>
                                 <view key="contentView" id="TZd-5p-NFL">
-                                    <rect key="frame" x="0.0" y="0.0" width="613" height="266"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="689" height="240"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RGE-Xv-zm5">
-                                            <rect key="frame" x="161" y="8" width="291" height="32"/>
+                                            <rect key="frame" x="199" y="8" width="291" height="32"/>
                                             <textFieldCell key="cell" alignment="center" id="k7C-e5-6a0">
                                                 <font key="font" metaFont="system"/>
                                                 <string key="title">In your Mac's menu bar, hold ⌘ and drag icons
@@ -433,7 +433,7 @@ between sections to configure Hidden Bar.</string>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vlT-cT-cRT">
-                                            <rect key="frame" x="57" y="141" width="110" height="28"/>
+                                            <rect key="frame" x="57" y="115" width="110" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Hidden" id="cXt-8R-PHo">
                                                 <font key="font" metaFont="system" size="24"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -441,7 +441,7 @@ between sections to configure Hidden Bar.</string>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U3K-oK-4ET">
-                                            <rect key="frame" x="209" y="141" width="78" height="28"/>
+                                            <rect key="frame" x="209" y="115" width="78" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Shown" id="iyS-g5-5mk">
                                                 <font key="font" metaFont="system" size="24"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -449,7 +449,7 @@ between sections to configure Hidden Bar.</string>
                                             </textFieldCell>
                                         </textField>
                                         <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pJz-eb-ydI">
-                                            <rect key="frame" x="87" y="206" width="439" height="22"/>
+                                            <rect key="frame" x="125" y="180" width="439" height="22"/>
                                             <subviews>
                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aFM-dG-B8C">
                                                     <rect key="frame" x="0.0" y="1" width="20" height="20"/>
@@ -570,7 +570,7 @@ between sections to configure Hidden Bar.</string>
                                             </customSpacing>
                                         </stackView>
                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EVs-2B-Bqx">
-                                            <rect key="frame" x="173" y="120" width="22" height="70"/>
+                                            <rect key="frame" x="173" y="94" width="22" height="70"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="12" id="4gg-ll-oij"/>
                                                 <constraint firstAttribute="height" constant="70" id="fjF-wG-847"/>
@@ -579,7 +579,7 @@ between sections to configure Hidden Bar.</string>
                                             <color key="contentTintColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                         </imageView>
                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uBw-I6-e5a">
-                                            <rect key="frame" x="509" y="120" width="22" height="70"/>
+                                            <rect key="frame" x="509" y="94" width="22" height="70"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="12" id="31o-Ut-bA7"/>
                                                 <constraint firstAttribute="height" constant="70" id="UhL-Ew-CZs"/>
@@ -588,7 +588,7 @@ between sections to configure Hidden Bar.</string>
                                             <color key="contentTintColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                         </imageView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eBG-Wk-IXv">
-                                            <rect key="frame" x="314" y="141" width="189" height="28"/>
+                                            <rect key="frame" x="314" y="115" width="189" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="⭐️Always Hidden" id="1jU-1x-cFf">
                                                 <font key="font" metaFont="system" size="24"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -614,7 +614,7 @@ between sections to configure Hidden Bar.</string>
                                 <color key="fillColor" name="quaternaryLabelColor" catalog="System" colorSpace="catalog"/>
                             </box>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aZz-jM-wCs">
-                                <rect key="frame" x="18" y="173" width="91" height="26"/>
+                                <rect key="frame" x="18" y="199" width="91" height="26"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Settings" id="1Is-Ut-a9h">
                                     <font key="font" metaFont="systemBold" size="22"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -622,13 +622,13 @@ between sections to configure Hidden Bar.</string>
                                 </textFieldCell>
                             </textField>
                             <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="35" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I1C-Eb-1or">
-                                <rect key="frame" x="16" y="20" width="581" height="133"/>
+                                <rect key="frame" x="16" y="20" width="657" height="159"/>
                                 <subviews>
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="do4-pv-o3U">
-                                        <rect key="frame" x="0.0" y="0.0" width="315" height="133"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="159"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cbR-Jv-adm">
-                                                <rect key="frame" x="-2" y="116" width="207" height="18"/>
+                                                <rect key="frame" x="-2" y="142" width="207" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Start Hidden Bar when I log in" bezelStyle="regularSquare" imagePosition="left" inset="2" id="W1G-55-zGo">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -638,7 +638,7 @@ between sections to configure Hidden Bar.</string>
                                                 </connections>
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gWT-L1-Xdf">
-                                                <rect key="frame" x="-2" y="90" width="198" height="18"/>
+                                                <rect key="frame" x="-2" y="116" width="198" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Show preferences on launch" bezelStyle="regularSquare" imagePosition="left" inset="2" id="hCh-Ue-NgH">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -648,7 +648,7 @@ between sections to configure Hidden Bar.</string>
                                                 </connections>
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EQP-7r-FSu">
-                                                <rect key="frame" x="-2" y="64" width="238" height="18"/>
+                                                <rect key="frame" x="-2" y="90" width="238" height="18"/>
                                                 <buttonCell key="cell" type="check" title="Use the full MenuBar on expanding" bezelStyle="regularSquare" imagePosition="left" inset="2" id="8z8-6N-wnc">
                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
@@ -658,7 +658,7 @@ between sections to configure Hidden Bar.</string>
                                                 </connections>
                                             </button>
                                             <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nE7-aX-FH9">
-                                                <rect key="frame" x="0.0" y="35" width="230" height="20"/>
+                                                <rect key="frame" x="0.0" y="61" width="230" height="20"/>
                                                 <subviews>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yaS-iD-h7g" userLabel="Check Box Show Always Hidden Section">
                                                         <rect key="frame" x="-2" y="1" width="204" height="18"/>
@@ -695,7 +695,7 @@ between sections to configure Hidden Bar.</string>
                                                 </customSpacing>
                                             </stackView>
                                             <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bf8-qr-hjT">
-                                                <rect key="frame" x="0.0" y="0.0" width="315" height="25"/>
+                                                <rect key="frame" x="0.0" y="26" width="315" height="25"/>
                                                 <subviews>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gj1-Ms-4No">
                                                         <rect key="frame" x="-2" y="4" width="206" height="22"/>
@@ -756,8 +756,19 @@ between sections to configure Hidden Bar.</string>
                                                     <real value="3.4028234663852886e+38"/>
                                                 </customSpacing>
                                             </stackView>
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9XT-0W-TvK">
+                                                <rect key="frame" x="-2" y="-1" width="236" height="18"/>
+                                                <buttonCell key="cell" type="check" title="Automatically expand and collapse" bezelStyle="regularSquare" imagePosition="left" inset="2" id="RNV-W5-IYi">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="autoExpandCollapse:" target="XfG-lQ-9wD" id="eyX-RY-8a8"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <visibilityPriorities>
+                                            <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
@@ -770,13 +781,14 @@ between sections to configure Hidden Bar.</string>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
                                         </customSpacing>
                                     </stackView>
                                     <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NOW-ql-i4U">
-                                        <rect key="frame" x="350" y="58" width="231" height="75"/>
+                                        <rect key="frame" x="350" y="84" width="307" height="75"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S0D-Ve-YKP">
-                                                <rect key="frame" x="62" y="58" width="108" height="17"/>
+                                                <rect key="frame" x="100" y="58" width="108" height="17"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Global Shortcut" id="HJP-Lf-rxm">
                                                     <font key="font" metaFont="systemMedium" size="14"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -784,7 +796,7 @@ between sections to configure Hidden Bar.</string>
                                                 </textFieldCell>
                                             </textField>
                                             <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="mtL-vU-2iq">
-                                                <rect key="frame" x="20" y="-4" width="191" height="56"/>
+                                                <rect key="frame" x="58" y="-4" width="191" height="56"/>
                                                 <view key="contentView" id="N9Y-29-pHK">
                                                     <rect key="frame" x="3" y="3" width="185" height="50"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -861,6 +873,7 @@ between sections to configure Hidden Bar.</string>
                         <outlet property="arrowPointToHiddenImage" destination="EVs-2B-Bqx" id="Bds-n4-dzK"/>
                         <outlet property="btnClear" destination="D4j-NZ-37N" id="2yc-ze-q1e"/>
                         <outlet property="btnShortcut" destination="yKf-P1-I45" id="AFr-y7-VbP"/>
+                        <outlet property="checkBoxAutoExpandCollapse" destination="9XT-0W-TvK" id="gQU-IR-FQE"/>
                         <outlet property="checkBoxAutoHide" destination="gj1-Ms-4No" id="Ibl-5H-2vh"/>
                         <outlet property="checkBoxLogin" destination="cbR-Jv-adm" id="DFO-De-0KU"/>
                         <outlet property="checkBoxShowAlwaysHiddenSection" destination="yaS-iD-h7g" id="T5N-bN-yl2"/>

--- a/hidden/Common/Assets.swift
+++ b/hidden/Common/Assets.swift
@@ -10,14 +10,14 @@ import AppKit
 
 struct Assets {
     static var expandImage: NSImage? {
-        if (Constant.isUsingLTRLanguage) {
+        if (Util.SharedValues.isUsingLTRLanguage) {
             return NSImage(named: NSImage.Name("ic_expand"))
         } else {
             return NSImage(named: NSImage.Name("ic_collapse"))
         }
     }
     static var collapseImage: NSImage? {
-        if (Constant.isUsingLTRLanguage) {
+        if (Util.SharedValues.isUsingLTRLanguage) {
             return NSImage(named: NSImage.Name("ic_collapse"))
         } else {
             return NSImage(named: NSImage.Name("ic_expand"))

--- a/hidden/Common/Constant.swift
+++ b/hidden/Common/Constant.swift
@@ -11,6 +11,4 @@ import Foundation
 enum Constant {
     static let appName = "Hidden Bar"
     static let launcherAppId = "com.dwarvesv.LauncherApplication"
-    
-    static var isUsingLTRLanguage = false
 }

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -79,7 +79,6 @@ enum Preferences {
             UserDefaults.standard.bool(forKey: UserDefaults.Key.autoExpandCollapse)
         }
         set {
-            print(newValue)
             UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.autoExpandCollapse)
             
             NotificationCenter.default.post(Notification(name: .prefsChanged))

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -74,6 +74,18 @@ enum Preferences {
         }
     }
     
+    static var autoExpandCollapse: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaults.Key.autoExpandCollapse)
+        }
+        set {
+            print(newValue)
+            UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.autoExpandCollapse)
+            
+            NotificationCenter.default.post(Notification(name: .prefsChanged))
+        }
+    }
+    
     static var areSeparatorsHidden: Bool {
         get {
             UserDefaults.standard.bool(forKey: UserDefaults.Key.areSeparatorsHidden)

--- a/hidden/Common/Util.swift
+++ b/hidden/Common/Util.swift
@@ -29,5 +29,12 @@ class Util {
         let prefWindow = PreferencesWindowController.shared.window
         prefWindow?.bringToFront()
     }
+    
+    static var screenWithMouse : NSScreen? {
+      let mouseLocation = NSEvent.mouseLocation
+      let screens = NSScreen.screens
+      let screenWithMouse = (screens.first { NSMouseInRect(mouseLocation, $0.frame, false) })
+      return screenWithMouse
+    }
    
 }

--- a/hidden/Extensions/CGPoint+Extension.swift
+++ b/hidden/Extensions/CGPoint+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  CGPoint+Extension.swift
+//  Hidden Bar
+//
+//  Created by Peter Luo on 2021/5/31.
+//  Copyright © 2021 Dwarves Foundation. All rights reserved.
+//
+
+import Foundation
+
+extension CGPoint {
+    static func ~=(lhs: CGPoint, rhs: CGPoint) -> Bool {
+        Int(lhs.x) == Int(rhs.x) && Int(lhs.y) == Int(rhs.y)
+    }
+}

--- a/hidden/Extensions/UserDefault+Extension.swift
+++ b/hidden/Extensions/UserDefault+Extension.swift
@@ -15,6 +15,7 @@ extension UserDefaults {
         static let isAutoStart = "isAutoStart"
         static let isAutoHide = "isAutoHide"
         static let isShowPreference = "isShowPreferences"
+        static let autoExpandCollapse = "autoExpandCollapse"
         static let areSeparatorsHidden = "areSeparatorsHidden"
         static let alwaysHiddenSectionEnabled = "alwaysHiddenSectionEnabled"
         static let useFullStatusBarOnExpandEnabled = "useFullStatusBarOnExpandEnabled"

--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -30,6 +30,7 @@ class PreferencesViewController: NSViewController {
     @IBOutlet weak var checkBoxLogin: NSButton!
     @IBOutlet weak var checkBoxShowPreferences: NSButton!
     @IBOutlet weak var checkBoxShowAlwaysHiddenSection: NSButton!
+    @IBOutlet weak var checkBoxAutoExpandCollapse: NSButton!
     
     @IBOutlet weak var checkBoxUseFullStatusbar: NSButton!
     @IBOutlet weak var timePopup: NSPopUpButton!
@@ -74,6 +75,9 @@ class PreferencesViewController: NSViewController {
         Preferences.isShowPreference = sender.state == .on
     }
     
+    @IBAction func autoExpandCollapse(_ sender: NSButton) {
+        Preferences.autoExpandCollapse = sender.state == .on
+    }
     
     @IBAction func showAlwaysHiddenSectionChanged(_ sender: NSButton) {
         Preferences.alwaysHiddenSectionEnabled = sender.state == .on
@@ -156,6 +160,7 @@ class PreferencesViewController: NSViewController {
         checkBoxAutoHide.state = Preferences.isAutoHide ? .on : .off
         checkBoxShowPreferences.state = Preferences.isShowPreference ? .on : .off
         checkBoxShowAlwaysHiddenSection.state = Preferences.alwaysHiddenSectionEnabled ? .on : .off
+        checkBoxAutoExpandCollapse.state = Preferences.autoExpandCollapse ? .on : .off
         timePopup.selectItem(at: SelectedSecond.secondToPossition(seconds: Preferences.numberOfSecondForAutoHide))
     }
     

--- a/hidden/Features/StatusBar/MouseOverDetector.swift
+++ b/hidden/Features/StatusBar/MouseOverDetector.swift
@@ -18,24 +18,17 @@ class MouseOverDetector {
     var entersAreaHandler : ()->Void
     var leavesAreaHandler : (Bool)->Void // $0: whether or not the mouse has clicked inside the area before leaving
     
-    private var statusBarY  : CGFloat
+    private var statusBarY  : CGFloat = .nan
     private var mouseMoveMoniter : EventMoniter?
     private var mouseClickMoniters  = [EventMoniter]()
+    
+    private var previousMouseLocation: CGPoint = .zero
     
     init(entersArea entersAreaHandler: @escaping ()->Void, leavesArea leavesAreaHandler: @escaping (Bool)->Void) {
         self.entersAreaHandler = entersAreaHandler
         self.leavesAreaHandler = leavesAreaHandler
         
-        if let statusbarRect = WindowInfo.cgRectOfWindow(named: "Menubar"),
-           let currentScreen = NSScreen.main {
-            // Cocoa uses top to down y coords but CoreGraphics uses down to top coords
-            // To avoid convertion everytime, statusBarY is inverted on initialize
-            statusBarY = currentScreen.frame.height - statusbarRect.height
-            print(statusbarRect.height)
-        } else {
-            os_log("Unable to get status bar height")
-            statusBarY = .nan
-        }
+        updateMenubarMinY()
         mouseMoveMoniter = EventMoniter(eventType: .mouseMoved, handler: mouseMoved)
         mouseClickMoniters = [
             EventMoniter(eventType: .leftMouseUp , handler: mouseClicked),
@@ -53,7 +46,24 @@ class MouseOverDetector {
         }
     }
     
+    private func updateMenubarMinY() {
+        if let statusbarRect = WindowInfo.cgRectOfWindow(named: "Menubar"),
+           let currentScreen = Util.screenWithMouse {
+            // Cocoa uses top to down y coords but CoreGraphics uses down to top coords
+            // To avoid convertion everytime, statusBarY is inverted on initialize
+            statusBarY = currentScreen.frame.height - statusbarRect.height
+        } else {
+            os_log("unable to get menu bar height")
+        }
+    }
+    
     private func mouseMoved(_ event: NSEvent) {
+        // must have at least 1 pixel of difference before proceeding
+        guard !(NSEvent.mouseLocation ~= previousMouseLocation) else { return }
+        if NSScreen.screens.count > 1 {
+            updateMenubarMinY()
+        }
+        
         if mouseIsInArea {
             if NSEvent.mouseLocation.y < statusBarY { // leaves area
                 leavesAreaHandler(mouseClickedInsideArea)

--- a/hidden/Features/StatusBar/MouseOverDetector.swift
+++ b/hidden/Features/StatusBar/MouseOverDetector.swift
@@ -18,7 +18,7 @@ class MouseOverDetector {
     var entersAreaHandler : ()->Void
     var leavesAreaHandler : (Bool)->Void // $0: whether or not the mouse has clicked inside the area before leaving
     
-    private var statusBarY  : CGFloat = .nan
+    private var statusBarY : CGFloat = .nan
     private var mouseMoveMoniter : EventMoniter?
     private var mouseClickMoniters  = [EventMoniter]()
     
@@ -57,8 +57,13 @@ class MouseOverDetector {
         if let statusbarRect = WindowInfo.cgRectOfWindow(named: "Menubar"),
            let currentScreen = Util.screenWithMouse {
             // Cocoa uses top to down y coords but CoreGraphics uses down to top coords
-            // To avoid convertion everytime, statusBarY is inverted on initialize
+            // to avoid convertion everytime, statusBarY is inverted on initialize
+            
+            Util.SharedValues.statusbarHeight = statusbarRect.height
+            Util.SharedValues.screenWidth     = currentScreen.frame.width
+            Util.SharedValues.screenHeight    = currentScreen.frame.height
             statusBarY = currentScreen.frame.height - statusbarRect.height
+            
         } else {
             os_log("unable to get menu bar height")
         }

--- a/hidden/Features/StatusBar/MouseOverDetector.swift
+++ b/hidden/Features/StatusBar/MouseOverDetector.swift
@@ -1,0 +1,71 @@
+//
+//  MouseOverDetector.swift
+//  Hidden Bar
+//
+//  Created by Peter Luo on 2021/5/31.
+//  Copyright © 2021 Dwarves Foundation. All rights reserved.
+//
+
+import AppKit
+import os // for os_log
+
+class MouseOverDetector {
+    
+    // flags
+    var mouseIsInArea = false
+    var mouseClickedInsideArea = false
+    
+    var entersAreaHandler : ()->Void
+    var leavesAreaHandler : (Bool)->Void // $0: whether or not the mouse has clicked inside the area before leaving
+    
+    private var statusBarY  : CGFloat
+    private var mouseMoveMoniter : EventMoniter?
+    private var mouseClickMoniters  = [EventMoniter]()
+    
+    init(entersArea entersAreaHandler: @escaping ()->Void, leavesArea leavesAreaHandler: @escaping (Bool)->Void) {
+        self.entersAreaHandler = entersAreaHandler
+        self.leavesAreaHandler = leavesAreaHandler
+        
+        if let statusbarRect = WindowInfo.cgRectOfWindow(named: "Menubar"),
+           let currentScreen = NSScreen.main {
+            // Cocoa uses top to down y coords but CoreGraphics uses down to top coords
+            // To avoid convertion everytime, statusBarY is inverted on initialize
+            statusBarY = currentScreen.frame.height - statusbarRect.height
+            print(statusbarRect.height)
+        } else {
+            os_log("Unable to get status bar height")
+            statusBarY = .nan
+        }
+        mouseMoveMoniter = EventMoniter(eventType: .mouseMoved, handler: mouseMoved)
+        mouseClickMoniters = [
+            EventMoniter(eventType: .leftMouseUp , handler: mouseClicked),
+            EventMoniter(eventType: .rightMouseUp, handler: mouseClicked),
+            EventMoniter(eventType: .otherMouseUp, handler: mouseClicked),
+        ]
+        
+        mouseMoveMoniter?.start()
+        mouseClickMoniters.forEach { $0.start() }
+    }
+    
+    private func mouseClicked(_ event: NSEvent) {
+        if NSEvent.mouseLocation.y >= statusBarY { // clicks inside the status bar
+            mouseClickedInsideArea = true
+        }
+    }
+    
+    private func mouseMoved(_ event: NSEvent) {
+        if mouseIsInArea {
+            if NSEvent.mouseLocation.y < statusBarY { // leaves area
+                leavesAreaHandler(mouseClickedInsideArea)
+                mouseIsInArea = false
+            }
+        } else {
+            if NSEvent.mouseLocation.y >= statusBarY { // enters area
+                mouseClickedInsideArea = false
+                entersAreaHandler()
+                mouseIsInArea = true
+            }
+        }
+    }
+    
+}

--- a/hidden/Features/StatusBar/MouseOverDetector.swift
+++ b/hidden/Features/StatusBar/MouseOverDetector.swift
@@ -35,9 +35,16 @@ class MouseOverDetector {
             EventMoniter(eventType: .rightMouseUp, handler: mouseClicked),
             EventMoniter(eventType: .otherMouseUp, handler: mouseClicked),
         ]
-        
+    }
+    
+    func start() {
         mouseMoveMoniter?.start()
         mouseClickMoniters.forEach { $0.start() }
+    }
+    
+    func stop() {
+        mouseMoveMoniter?.stop()
+        mouseClickMoniters.forEach { $0.stop() }
     }
     
     private func mouseClicked(_ event: NSEvent) {

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -12,6 +12,7 @@ class StatusBarController {
     
     //MARK: - Variables
     private var timer:Timer? = nil
+    private var mouseOverDetector : MouseOverDetector?
     
     //MARK: - BarItems
         
@@ -69,6 +70,11 @@ class StatusBarController {
         
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
+        
+        mouseOverDetector = MouseOverDetector(
+            entersArea: expandMenubar,
+            leavesArea: { if !$0 {self.collapseMenuBar()} }
+        )
     }
     
     private func setupUI() {

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -75,6 +75,8 @@ class StatusBarController {
             entersArea: expandMenubar,
             leavesArea: { if !$0 {self.collapseMenuBar()} }
         )
+        
+        updatePrefs()
     }
     
     private func setupUI() {
@@ -199,7 +201,7 @@ class StatusBarController {
         let toggleAutoHideItem = NSMenuItem(title: "Toggle Auto Collapse".localized, action: #selector(toggleAutoHide), keyEquivalent: "t")
         toggleAutoHideItem.target = self
         toggleAutoHideItem.tag = 1
-        NotificationCenter.default.addObserver(self, selector: #selector(updateAutoHide), name: .prefsChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updatePrefs), name: .prefsChanged, object: nil)
         menu.addItem(toggleAutoHideItem)
 
         menu.addItem(NSMenuItem.separator())
@@ -217,9 +219,16 @@ class StatusBarController {
         }
     }
     
-    @objc func updateAutoHide() {
+    @objc func updatePrefs() {
         updateAutoCollapseMenuTitle()
         autoCollapseIfNeeded()
+        
+        if Preferences.autoExpandCollapse {
+            mouseOverDetector?.stop()
+            mouseOverDetector?.start()
+        } else {
+            mouseOverDetector?.stop()
+        }
     }
     
     @objc func openPreferenceViewControllerIfNeeded() {

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -32,18 +32,22 @@ class StatusBarController {
         return self.separateStatusBar.length == self.collapseSeparateStatusBarIconLength
     }
     
+    // used when collapsing
     private var isValidPosition: Bool {
         guard
+            !Util.menubarIsInUse,
             let expandBarButtonX = self.expandCollapseStatusBar.button?.getOrigin?.x,
             let separateBarButtonX = self.separateStatusBar.button?.getOrigin?.x
             else {return false}
         
-        if Constant.isUsingLTRLanguage {
+        if Util.SharedValues.isUsingLTRLanguage {
             return expandBarButtonX >= separateBarButtonX
         } else {
             return expandBarButtonX <= separateBarButtonX
         }
     }
+    
+    // used when hiding always hide seperation bar
     private var isValidTogglablePosition: Bool {
         if !Preferences.alwaysHiddenSectionEnabled { return true }
         
@@ -52,7 +56,7 @@ class StatusBarController {
             let terminateBarButtonX = self.alwayHideSeparateStatusBar?.button?.getOrigin?.x
             else {return false}
         
-        if Constant.isUsingLTRLanguage {
+        if Util.SharedValues.isUsingLTRLanguage {
             return separateBarButtonX >= terminateBarButtonX
         } else {
             return separateBarButtonX <= terminateBarButtonX

--- a/hidden/Models/EventMoniter.swift
+++ b/hidden/Models/EventMoniter.swift
@@ -29,6 +29,9 @@ class EventMoniter {
     }
     
     func stop() {
+        guard globalMoniter != nil && localMoniter != nil else { return }
+        NSEvent.removeMonitor(globalMoniter!)
+        NSEvent.removeMonitor(localMoniter!)
         globalMoniter = nil
         localMoniter  = nil
     }

--- a/hidden/Models/EventMoniter.swift
+++ b/hidden/Models/EventMoniter.swift
@@ -1,0 +1,40 @@
+//
+//  EventMoniter.swift
+//  Hidden Bar
+//
+//  Created by Peter Luo on 2021/5/31.
+//  Copyright © 2021 Dwarves Foundation. All rights reserved.
+//
+
+import AppKit
+
+class EventMoniter {
+    
+    var globalMoniter : Any?
+    var localMoniter  : Any?
+    var handler       : (NSEvent)->Void
+    var eventType     : NSEvent.EventTypeMask
+    
+    init(eventType: NSEvent.EventTypeMask, handler: @escaping (NSEvent)->Void) {
+        self.handler = handler
+        self.eventType = eventType
+    }
+    
+    func start() {
+        globalMoniter = NSEvent.addGlobalMonitorForEvents(matching: eventType, handler: handler)
+        localMoniter  = NSEvent.addLocalMonitorForEvents(matching: eventType) { event in
+            self.handler(event)
+            return event
+        }
+    }
+    
+    func stop() {
+        globalMoniter = nil
+        localMoniter  = nil
+    }
+    
+    deinit {
+        stop()
+    }
+    
+}

--- a/hidden/Models/WindowInfo.swift
+++ b/hidden/Models/WindowInfo.swift
@@ -1,0 +1,47 @@
+//
+//  WindowInfo.swift
+//  Hidden Bar
+//
+//  Created by Peter Luo on 2021/5/31.
+//  Copyright © 2021 Dwarves Foundation. All rights reserved.
+//
+
+import AppKit
+
+class WindowInfo {
+    
+    enum InfoType : String {
+         case alpha = "kCGWindowAlpha"
+         case bounds = "kCGWindowBounds"
+         case ownerName = "kCGWindowOwnerName"
+         case ownerPID = "kCGWindowOwnerPID"
+         case number = "kCGWindowNumber"
+         case name = "kCGWindowName"
+         case layer = "kCGWindowLayer"
+    }
+    
+    static var infoList : [ [ String : Any ] ]? {
+         let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements, .optionOnScreenOnly)
+         guard let infoList = CGWindowListCopyWindowInfo(options, CGWindowID(0)) else { return nil }
+         return (infoList as! [[String : Any]])
+     }
+    
+    static func infoFor(windowNamed windowName: String, infoType: WindowInfo.InfoType) -> Any? {
+        guard let infoList = WindowInfo.infoList else { return nil }
+        for info in infoList {
+            if let name = info["kCGWindowName"] as? String, name == windowName {
+                return info[infoType.rawValue]
+            }
+        }
+        return nil
+    }
+    
+    static func cgRectOfWindow(named windowName: String) -> CGRect? {
+        guard let bounds = WindowInfo.infoFor(windowNamed: windowName, infoType: .bounds),
+               let cgRect = CGRect(dictionaryRepresentation: bounds as! CFDictionary)
+         else { return nil }
+
+         return cgRect
+     }
+    
+}


### PR DESCRIPTION
#### What's this PR do?

- Automatically expand or collapse when mouse hovers on the menu bar
- Stops collapse if the mouse clicked inside the menu bar area before leaving
- Works with multiple screens

#### What are the relevant Git tickets?

#115 was a very similar PR also by me but it was closed because the code and commit history is messy and it has merge conflicts with the develop branch.

#### Any background context you want to provide? (if appropriate)
Behavior:
1. Expands the menu bar when the mouse is inside the menu bar area
2. When the mouse leaves menu bar area and did not click on the menu bar, status bar collapses