### PR TITLE
fix: reduce potential menu bar memory growth from oversized collapsed widths

### DIFF
--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -19,11 +19,11 @@ class StatusBarController {
     private let btnSeparate = NSStatusBar.system.statusItem(withLength: 1)
     private var btnAlwaysHidden:NSStatusItem? = nil
     
-    private var btnHiddenLength: CGFloat =  20
-    private let btnHiddenCollapseLength: CGFloat = 10000
+    private var btnHiddenLength: CGFloat = 20
+    private var btnHiddenCollapseLength: CGFloat = 2000
     
-    private let btnAlwaysHiddenLength: CGFloat = Preferences.alwaysHiddenSectionEnabled ? 20 : 0
-    private let btnAlwaysHiddenEnableExpandCollapseLength: CGFloat = Preferences.alwaysHiddenSectionEnabled ? 10000 : 0
+    private var btnAlwaysHiddenLength: CGFloat = Preferences.alwaysHiddenSectionEnabled ? 20 : 0
+    private var btnAlwaysHiddenEnableExpandCollapseLength: CGFloat = Preferences.alwaysHiddenSectionEnabled ? 2000 : 0
     
     private let imgIconLine = NSImage(named:NSImage.Name("ic_line"))
     
@@ -63,15 +63,33 @@ class StatusBarController {
     
     //MARK: - Methods
     init() {
-        
+        updateCollapsedLengths()
         setupUI()
         setupAlwayHideStatusBar()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleScreenParametersChanged), name: NSApplication.didChangeScreenParametersNotification, object: nil)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
             self.collapseMenuBar()
         })
         
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    @objc private func handleScreenParametersChanged() {
+        updateCollapsedLengths()
+    }
+    
+    private func updateCollapsedLengths() {
+        let screenWidth = NSScreen.main?.visibleFrame.width ?? 1728
+        // Keep collapse length bounded to avoid pathological layout/memory behavior
+        // on newer macOS versions while still fully hiding the trailing section.
+        let boundedCollapseLength = max(500, min(screenWidth + 200, 4000))
+        btnHiddenCollapseLength = boundedCollapseLength
+        btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? boundedCollapseLength : 0
     }
     
     private func setupUI() {
@@ -242,15 +260,22 @@ extension StatusBarController {
         toggleStatusBarIfNeeded()
     }
     @objc private func toggleStatusBarIfNeeded() {
+        updateCollapsedLengths()
+        
         if Preferences.alwaysHiddenSectionEnabled {
-            self.btnAlwaysHidden =  NSStatusBar.system.statusItem(withLength: 20)
+            if let existing = self.btnAlwaysHidden {
+                NSStatusBar.system.removeStatusItem(existing)
+            }
+            self.btnAlwaysHidden = NSStatusBar.system.statusItem(withLength: btnAlwaysHiddenLength)
             if let button = btnAlwaysHidden?.button {
                 button.image = self.imgIconLine
                 button.appearsDisabled = true
             }
-            self.btnAlwaysHidden?.autosaveName = "hiddenbar_terminate";
-            
-        }else {
+            self.btnAlwaysHidden?.autosaveName = "hiddenbar_terminate"
+        } else {
+            if let existing = self.btnAlwaysHidden {
+                NSStatusBar.system.removeStatusItem(existing)
+            }
             self.btnAlwaysHidden = nil
         }
     }


### PR DESCRIPTION
## Summary
This PR addresses high-memory reports (see #326) by removing oversized status item collapse widths that can trigger expensive menu bar layout behavior on newer macOS versions.

Closes #343.

## Root cause hypothesis
`StatusBarController` used very large hardcoded collapse lengths (`10000`) for status items when hiding sections.
On newer macOS builds, oversized status item geometry appears to cause pathological layout/repaint work, which aligns with reports of Hidden consuming multiple GB of RAM.

## What changed
- Replaced hardcoded large collapse lengths with a **dynamic bounded width** based on current screen width.
  - New bounded formula: `max(500, min(screenWidth + 200, 4000))`
- Recompute collapse lengths when display configuration changes via:
  - `NSApplication.didChangeScreenParametersNotification`
- Added cleanup safety:
  - `deinit` now removes observers.
- Fixed status item lifecycle in always-hidden toggle:
  - Explicitly remove old `NSStatusItem` from `NSStatusBar` before replacing/nilling.

## Why this is safe
- Behavior remains functionally the same (collapsed section still fully hidden).
- Uses realistic, bounded geometry instead of extreme values.
- Should reduce risk of memory growth while preserving UX.

## Validation notes
I couldn’t run full `xcodebuild` in this environment because full Xcode isn’t installed (only Command Line Tools). Please validate on macOS 15/26 with Activity Monitor after repeated collapse/expand + auto-hide cycles.
