### PR TITLE
Fix: resolve memory leaks and remove debug info leakage

### DIFF
--- a/LauncherApplication/AppDelegate.swift
+++ b/LauncherApplication/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
+        DistributedNotificationCenter.default().removeObserver(self)
     }
     
     

--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -47,6 +47,10 @@ class PreferencesViewController: NSViewController {
         }
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     //MARK: - VC Life cycle
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -67,9 +67,9 @@ class StatusBarController {
         setupUI()
         setupAlwayHideStatusBar()
         NotificationCenter.default.addObserver(self, selector: #selector(handleScreenParametersChanged), name: NSApplication.didChangeScreenParametersNotification, object: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-            self.collapseMenuBar()
-        })
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.collapseMenuBar()
+        }
         
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
@@ -157,8 +157,8 @@ class StatusBarController {
         if isToggle {return}
         isToggle = true
         self.isCollapsed ? self.expandMenubar() : self.collapseMenuBar()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            self.isToggle = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.isToggle = false
         }
     }
     

--- a/hidden/Models/GlobalKeybindingPreferences.swift
+++ b/hidden/Models/GlobalKeybindingPreferences.swift
@@ -20,7 +20,6 @@ struct GlobalKeybindPreferences: Codable, CustomStringConvertible {
     let keyCode : UInt32
 
     var description: String {
-        print(keyCode)
         var stringBuilder = ""
         if self.function {
             stringBuilder += "Fn"


### PR DESCRIPTION
## Summary

  - Remove debug `print(keyCode)` in `GlobalKeybindingPreferences.description` that leaked user hotkey data to the
  system console
  - Add `removeObserver(self)` in `LauncherApplication/AppDelegate.applicationWillTerminate` —
  `DistributedNotificationCenter` does not use zeroing-weak references, so unremoved observers risk a crash on dealloc
  - Add `deinit` with `removeObserver(self)` to `PreferencesViewController` — observer registered in `viewDidLoad` had
  no cleanup path
  - Use `[weak self]` in two `DispatchQueue.main.asyncAfter` closures in `StatusBarController` to prevent retaining
  `self` beyond intended lifetime

  ## Test plan

  - [ ] Verify global hotkey still works after setting it in Preferences
  - [ ] Open and close Preferences window multiple times, confirm no observer accumulation (use Instruments Allocations)
  - [ ] Confirm LauncherApplication terminates cleanly without console crash logs
  - [ ] Confirm auto-collapse timer still fires correctly after expanding the menu bar
  - [ ] Verify no `keyCode` output appears in Console.app during normal usage