### PR TITLE
fix: properly hide menu bar items on ultra-wide monitors

### DIFF
--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		92C97B8D220058740007559C /* NSView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C97B8C220058740007559C /* NSView+Extension.swift */; };
 		92C97B8F220147FE0007559C /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C97B8E220147FE0007559C /* Constant.swift */; };
 		92C97B9122018C1F0007559C /* StatusBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C97B9022018C1F0007559C /* StatusBarController.swift */; };
+		AA1234560001000000000001 /* MenuBarOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234560001000000000002 /* MenuBarOverlayWindow.swift */; };
 		92D2122221FEE06600C92FF4 /* LauncherApplication.app in Sources */ = {isa = PBXBuildFile; fileRef = 92C5054E21FEC03B0084719A /* LauncherApplication.app */; };
 		967F4B2524169BC800F18D3C /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F4B2424169BC800F18D3C /* String+Extension.swift */; };
 		967F4B2824169CAF00F18D3C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 967F4B2A24169CAF00F18D3C /* Localizable.strings */; };
@@ -103,6 +104,7 @@
 		92C97B8C220058740007559C /* NSView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Extension.swift"; sourceTree = "<group>"; };
 		92C97B8E220147FE0007559C /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		92C97B9022018C1F0007559C /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
+		AA1234560001000000000002 /* MenuBarOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarOverlayWindow.swift; sourceTree = "<group>"; };
 		967F4B2424169BC800F18D3C /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		967F4B2924169CAF00F18D3C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		967F4B2B24169CB200F18D3C /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				92C97B9022018C1F0007559C /* StatusBarController.swift */,
+				AA1234560001000000000002 /* MenuBarOverlayWindow.swift */,
 			);
 			path = StatusBar;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */,
 				08A5F86123AA085B00981CA5 /* Preferences.swift in Sources */,
 				92C97B9122018C1F0007559C /* StatusBarController.swift in Sources */,
+				AA1234560001000000000001 /* MenuBarOverlayWindow.swift in Sources */,
 				55F3F1192608923B0054B881 /* Date+Extension.swift in Sources */,
 				92D2122221FEE06600C92FF4 /* LauncherApplication.app in Sources */,
 				08B9F32C2411883300AA0551 /* NSWindow+Extension.swift in Sources */,

--- a/hidden/Features/StatusBar/MenuBarOverlayWindow.swift
+++ b/hidden/Features/StatusBar/MenuBarOverlayWindow.swift
@@ -1,0 +1,48 @@
+//
+//  MenuBarOverlayWindow.swift
+//  Hidden Bar
+//
+//  Created for ultra-wide monitor support.
+//  Covers menu bar items that macOS won't push off-screen.
+//
+
+import AppKit
+
+class MenuBarOverlayWindow: NSPanel {
+
+    override var canBecomeKey: Bool { return false }
+    override var canBecomeMain: Bool { return false }
+
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+
+        // Window configuration: sit just above status items so we cover them.
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.statusWindow)) + 1)
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        isOpaque = true
+        backgroundColor = .black
+        hasShadow = false
+        ignoresMouseEvents = false  // Block clicks on covered items when collapsed
+        isReleasedWhenClosed = false
+    }
+
+    /// Show the overlay covering the specified frame in screen coordinates.
+    func showOverlay(frame: NSRect) {
+        guard frame.width > 1 && frame.height > 0 else {
+            hideOverlay()
+            return
+        }
+        setFrame(frame, display: true)
+        orderFrontRegardless()
+    }
+
+    /// Hide the overlay.
+    func hideOverlay() {
+        orderOut(nil)
+    }
+}

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -12,6 +12,7 @@ class StatusBarController {
     
     //MARK: - Variables
     private var timer:Timer? = nil
+    private lazy var overlayWindow = MenuBarOverlayWindow()
     
     //MARK: - BarItems
         
@@ -28,7 +29,9 @@ class StatusBarController {
     private let imgIconLine = NSImage(named:NSImage.Name("ic_line"))
     
     private var isCollapsed: Bool {
-        return self.btnSeparate.length == self.btnHiddenCollapseLength
+        // Use a threshold instead of exact equality so that a screen-change
+        // recalculation of btnHiddenCollapseLength doesn't break state detection.
+        return self.btnSeparate.length > self.btnHiddenLength
     }
     
     private var isBtnSeparateValidPosition: Bool {
@@ -80,16 +83,31 @@ class StatusBarController {
     }
     
     @objc private func handleScreenParametersChanged() {
+        let wasCollapsed = isCollapsed
         updateCollapsedLengths()
+        // If the bar was collapsed, re-apply the new collapse length and
+        // reposition the overlay for the new display configuration.
+        if wasCollapsed {
+            btnSeparate.length = btnHiddenCollapseLength
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.showOverlayIfNeeded()
+            }
+        }
     }
     
     private func updateCollapsedLengths() {
-        let screenWidth = NSScreen.main?.visibleFrame.width ?? 1728
-        // Keep collapse length bounded to avoid pathological layout/memory behavior
-        // on newer macOS versions while still fully hiding the trailing section.
-        let boundedCollapseLength = max(500, min(screenWidth + 200, 4000))
-        btnHiddenCollapseLength = boundedCollapseLength
-        btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? boundedCollapseLength : 0
+        // Determine the screen where status items live by checking the button's
+        // window. Fall back to NSScreen.main, then the first screen.
+        // macOS enforces a hard maximum of 10,000 for NSStatusItem length, so we
+        // cap at that value.  On ultra-wide monitors where 10,000 isn't enough to
+        // push all items off-screen, the overlay window covers the remainder.
+        let screen = btnExpandCollapse.button?.window?.screen
+                     ?? NSScreen.main
+                     ?? NSScreen.screens.first
+        let screenWidth = screen?.frame.width ?? 1728
+        let collapseLength = max(500, min(screenWidth * 2, 10000))
+        btnHiddenCollapseLength = collapseLength
+        btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? collapseLength : 0
     }
     
     private func setupUI() {
@@ -176,9 +194,16 @@ class StatusBarController {
             NSApp.setActivationPolicy(.accessory)
             NSApp.deactivate()
         }
+        
+        // After macOS finishes repositioning status items, show overlay to
+        // cover any items that couldn't be pushed off-screen (ultra-wide).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.showOverlayIfNeeded()
+        }
     }
     private func expandMenubar() {
         guard self.isCollapsed else {return}
+        overlayWindow.hideOverlay()
         btnSeparate.length = btnHiddenLength
         if let button = btnExpandCollapse.button {
             button.image = Assets.collapseImage
@@ -197,6 +222,54 @@ class StatusBarController {
         guard !isCollapsed else { return }
         
         startTimerToAutoHide()
+    }
+    
+    /// Calculate the overlay frame and show it to cover any hidden items that
+    /// macOS couldn't push off the left edge of the screen (ultra-wide monitors).
+    private func showOverlayIfNeeded() {
+        guard isCollapsed else {
+            overlayWindow.hideOverlay()
+            return
+        }
+        
+        // Find the screen where the status items live (via the toggle button's window).
+        guard let buttonWindow = btnExpandCollapse.button?.window,
+              let screen = buttonWindow.screen else {
+            overlayWindow.hideOverlay()
+            return
+        }
+        
+        // Menu bar height: on the primary screen we can derive it from the
+        // visible-frame inset; on secondary screens macOS often reports
+        // visibleFrame == frame, so fall back to NSStatusBar.system.thickness.
+        var menuBarHeight = screen.frame.maxY - screen.visibleFrame.maxY
+        if menuBarHeight < 1 {
+            menuBarHeight = NSStatusBar.system.thickness
+        }
+        
+        // The overlay covers from just past the app menu zone up to the left
+        // edge of the expand/collapse button's window.  We leave a 600pt
+        // margin on the left so the Apple logo and application menus (e.g.
+        // Chrome  File  Edit  View …) remain visible and clickable.
+        let appMenuMargin: CGFloat = 600
+        let overlayLeft = screen.frame.origin.x + appMenuMargin
+        let rightEdge = buttonWindow.frame.origin.x
+        let overlayWidth = rightEdge - overlayLeft
+        
+        // Only show the overlay if there's meaningful width to cover.
+        guard overlayWidth > 1 else {
+            overlayWindow.hideOverlay()
+            return
+        }
+        
+        let overlayFrame = NSRect(
+            x: overlayLeft,
+            y: screen.frame.maxY - menuBarHeight,
+            width: overlayWidth,
+            height: menuBarHeight
+        )
+        
+        overlayWindow.showOverlay(frame: overlayFrame)
     }
     
     private func startTimerToAutoHide() {


### PR DESCRIPTION
## Summary

- Fix menu bar items remaining visible on ultra-wide monitors (5120px+) when collapsed
- On ultra-wide screens, macOS enforces a hard 10,000pt max for `NSStatusItem.length` and prevents status items from crossing the app-menu boundary, causing hidden items to pile up visibly in the middle of the menu bar

## Problem

Hidden Bar works by expanding `btnSeparate` to a large width to push hidden status items off the left edge of the screen. On standard monitors this works fine, but on ultra-wide monitors (e.g. 5120px wide):

1. macOS caps `NSStatusItem.length` at 10,000pt
2. macOS divides the menu bar into app-menu (left) and status-item (right) zones — status items cannot cross into the app-menu zone
3. Hidden items pile up at the app-menu boundary and remain visible

## Solution

Added a `MenuBarOverlayWindow` — a solid-black `NSPanel` positioned just above the status bar level — that covers any hidden items macOS couldn't push off-screen.

### Changes

**New file: `MenuBarOverlayWindow.swift`**
- Borderless, non-activating `NSPanel` with solid black background
- Window level set just above `statusWindow` to cover stuck items
- Blocks clicks on covered items (`ignoresMouseEvents = false`)
- Joins all spaces and stays stationary

**Modified: `StatusBarController.swift`**
- Dynamically calculate collapse length using the screen where status items actually live (via `btnExpandCollapse.button?.window?.screen`), with fallbacks to `NSScreen.main` and `NSScreen.screens.first`
- Cap collapse length at macOS's hard 10,000pt maximum
- Show overlay 0.5s after collapsing (gives macOS time to finish repositioning items)
- Hide overlay immediately on expand
- Use `NSStatusBar.system.thickness` as fallback for menu bar height on secondary screens (where `visibleFrame == frame`)
- Leave 600px margin on the left so Apple menu and app menus remain visible and clickable
- Change `isCollapsed` to use threshold comparison (`> btnHiddenLength`) instead of exact equality, so screen-change recalculations don't break state detection
- Re-apply collapse length and reposition overlay on screen parameter changes

**Modified: `project.pbxproj`**
- Added `MenuBarOverlayWindow.swift` to build sources

## Testing

Tested on a 5120x1440 ultra-wide monitor as a secondary display alongside a MacBook screen. Hidden items are properly concealed when collapsed, and the Apple menu + app menus remain fully visible and functional.