### PR TITLE
Docs: architecture, manual, maintainer runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ brew install --cask hiddenbar
 	<img src="img/tutorial.gif">
 </p>
 
+## 📚 Documentation
+
+- [Manual](docs/MANUAL.md): every setting, the hidden Terminal-only options, and troubleshooting.
+- [Architecture](docs/ARCHITECTURE.md): how the hiding trick works, topology, and known limits.
+- [Maintainer runbook](docs/RUNBOOK.md): build, behavioral verification, and release process.
+
 ## ✨<a href="https://github.com/dwarvesf/hidden/graphs/contributors">Contributors</a>
 
 This project exists thanks to all the people who contribute. Thank you guys so much 👏

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,105 @@
+# Architecture
+
+Hidden Bar is a single-process, sandboxed AppKit menubar utility (~1.5k lines of
+Swift, one dependency: [HotKey](https://github.com/soffes/HotKey)). There is no
+helper app, no daemon, no network. Everything happens inside three
+`NSStatusItem`s and one window.
+
+## The core trick
+
+macOS offers no API to hide other apps' menubar icons. Hidden Bar fakes it with
+geometry: a separator status item whose **length is inflated to roughly the
+width of the widest attached screen**, shoving every icon to its left off-screen.
+Collapsing and expanding is just flipping that length between ~20pt and the
+inflated value.
+
+```mermaid
+flowchart LR
+    subgraph menubar [menu bar, right to left]
+        direction RL
+        ARROW["arrow item\n(toggle, variable length)"]
+        SEP["separator item\n20pt expanded / ~2x screen width collapsed"]
+        HIDDEN["other apps' icons\npushed off-screen when collapsed"]
+        ALWAYS["always-hidden separator\n(optional)"]
+    end
+    ARROW --- SEP --- HIDDEN --- ALWAYS
+```
+
+Key consequences of this design:
+
+- The menubar replicates on every display, so the collapse length derives from
+  the **widest** screen (`NSScreen.screens`), never `NSScreen.main`, and is
+  re-applied to the live item on `didChangeScreenParametersNotification`
+  (display hot-plug).
+- The length is bounded: `max(500, min(widestFrameWidth * 2, 10_000))`. macOS
+  enforces a hard 10,000pt maximum on `NSStatusItem.length`.
+- `isCollapsed` is derived state: `separator.length > 20`, deliberately not an
+  equality check, so it survives the length being recomputed while collapsed.
+- Icons macOS inserts to the LEFT of the separator (where new status items
+  appear) are in the hidden zone by default; that is inherent to the trick.
+
+## Topology
+
+```mermaid
+flowchart TD
+    AD[AppDelegate] -->|owns| SBC[StatusBarController]
+    AD -->|registers| SM["SMAppService.mainApp\n(login item, macOS 13+)"]
+    AD -->|global hotkey| HK[HotKey lib]
+    SBC -->|3 status items| NSB[NSStatusBar.system]
+    SBC -->|auto-hide| T["one-shot Timer\n(re-arms while pointer in menubar)"]
+    SBC -->|opt-in| HM["global mouseMoved monitor\n(hover-to-expand, only if pref on)"]
+    PREFS[Preferences facade] -->|UserDefaults| UD[(UserDefaults)]
+    PREFS -->|posts| NC{{NotificationCenter\n.prefsChanged / .alwayHideToggle}}
+    NC --> SBC
+    PVC[PreferencesViewController] --> PREFS
+    SBC -->|context menu| PVC
+```
+
+- **`AppDelegate`** (entry): registers default prefs, sets up the global hotkey,
+  runs the one-shot legacy login-item migration, owns the `StatusBarController`.
+- **`StatusBarController`** (the product, ~370 lines): the three status items,
+  collapse/expand, auto-hide timer, interaction-awareness, hover-to-expand,
+  self-restore of dragged-off items.
+- **`Preferences`** (facade enum): typed accessors over `UserDefaults`; setters
+  post `NotificationCenter` notifications that the controller and prefs window
+  observe. There is no other state store.
+- **`PreferencesViewController` / `PreferencesWindowController`**: the only
+  window (storyboard-based), shown on demand from the context menu.
+
+## Behavior layers on the core trick
+
+| Layer | Mechanism | Cost when unused |
+|---|---|---|
+| Auto-hide | one-shot `Timer` after expand; at fire, if the pointer sits in any screen's menubar band (`visibleFrame.maxY ... frame.maxY`), it re-arms instead of collapsing | none (single point-in-rect check at fire) |
+| Hover-to-expand (opt-in) | global `.mouseMoved` monitor + 0.5s dwell timer; installed only when the `hoverToExpand` default is true at launch | zero: monitor not installed |
+| Self-restore | `isVisible = true` forced on our items at launch; Cmd-dragging them off otherwise bricks the app (its only UI is those items) | none |
+| Always-hidden section | a second separator item; its own length games, gated by `alwaysHiddenSectionEnabled` | item not created |
+
+## Autostart
+
+macOS 13+ `SMAppService.mainApp`: the app registers itself; the login item is
+visible and revocable in System Settings > General > Login Items. On first
+launch after upgrade, a one-shot migration deauthorizes the legacy
+`com.dwarvesv.LauncherApplication` helper registration (the BTM database never
+garbage-collects those; see Apple TN3111). The helper app itself is gone.
+
+## Security posture
+
+Sandboxed (`com.apple.security.app-sandbox`), hardened runtime, no network
+entitlement, no file I/O, no IPC surface, no shell or subprocess use. The only
+dependency is HotKey (a small Carbon `RegisterEventHotKey` wrapper) locked by
+the committed `Package.resolved`. The opt-in hover monitor observes pointer
+position only and discards event payloads. About-window links are hardcoded.
+A full-tree audit (2026-06) scored 9/10 with hygiene-level findings only.
+
+## Known architectural limits
+
+- **The notch**: hidden icons sit "under" the notch area on notched Macs; the
+  trick cannot reveal them there. The real fix is a spillover/second-bar design
+  (tracked in issues #357/#341/#148; candidate implementations in PRs #350/#358).
+- **macOS 27**: the menu bar re-architecture in macOS 27 betas
+  (`NSMenuBarNavigationSceneExtension`) breaks length-inflation hiding entirely
+  (issue #360). A different mechanism may be required.
+- **Other apps' open menus**: interaction-awareness is pointer-position-based;
+  a pointer deep inside another app's open dropdown is below the menubar band,
+  so the collapse can still fire there.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1,0 +1,66 @@
+# Manual
+
+Everything Hidden Bar can do, including the parts with no UI.
+
+## Basics
+
+- **Left-click the arrow** (`<` / `>`): expand or collapse the hidden section.
+- **Right-click the arrow** or **left-click the separator** (`|`): context menu
+  (Preferences, Toggle Auto Collapse, Quit).
+- **⌘-drag** icons in the menu bar to move them across the separator: icons to
+  the separator's left are hidden when collapsed.
+- **Option-click the arrow**: show/hide the separators and the always-hidden
+  area without expanding.
+
+## Preferences window
+
+| Setting | What it does |
+|---|---|
+| Start Hidden Bar when I log in | Login item via System Settings (macOS 13+ `SMAppService`); revocable in System Settings > General > Login Items |
+| Show preferences on launch | Open this window at app start |
+| Auto collapse | Re-hide automatically after the chosen delay |
+| Global shortcut | System-wide expand/collapse hotkey (F-keys display as F18, not Fn18) |
+| Enable always hidden section | A second zone whose icons stay hidden even when expanded; revealed by option-clicking the arrow |
+| Use full menu bar on expanding | App becomes briefly "regular" while expanded (helps on tight menubars) |
+
+## Behaviors you get for free
+
+- **It won't collapse mid-use**: while your pointer is anywhere in the menu bar,
+  the auto-collapse countdown defers and restarts; it resumes when you leave.
+- **Self-repair**: if the arrow or separator was ⌘-dragged off the bar (which
+  used to make the app unreachable forever), they come back on next launch.
+- **Display changes**: plugging in or removing monitors re-sizes the hidden zone
+  for the widest attached screen automatically.
+
+## Hidden settings (Terminal)
+
+All via `defaults`; quit and relaunch the app after changing them.
+
+```sh
+# expand by hovering the menu bar for ~0.5s (off by default)
+defaults write com.dwarvesv.minimalbar hoverToExpand -bool true
+
+# auto-collapse delay in seconds (the UI offers a fixed list; any value works)
+defaults write com.dwarvesv.minimalbar numberOfSecondForAutoHide -float 5
+
+# force the app language regardless of system order (issue #287)
+defaults write com.dwarvesv.minimalbar AppleLanguages '(en)'
+```
+
+To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Icons I want visible got hidden after an update | ⌘-drag them to the right of the separator |
+| Login item missing after denying it once | System Settings > General > Login Items: re-enable Hidden Bar, then toggle the pref off/on |
+| A ghost "LauncherApplication" login item from old versions | Launch the current version once; it deauthorizes the legacy item automatically |
+| App language stuck | See the `AppleLanguages` command above, or System Settings > General > Language & Region > Applications |
+| Nothing hides on a macOS 27 beta | Known (issue #360); the menu bar re-architecture broke the hiding mechanism, fix under investigation |
+
+## Requirements
+
+macOS 13 Ventura or later. Pre-Ventura (10.13 - 12.x): use
+[v1.10](https://github.com/dwarvesf/hidden/releases/tag/v1.10), the last release
+on the old autostart mechanism.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,80 @@
+# Maintainer runbook
+
+Build, verify, and release Hidden Bar. Assumes current Xcode on macOS 13+.
+
+## Build
+
+```sh
+# CI-style build, no signing required
+xcodebuild -project 'Hidden Bar.xcodeproj' -scheme 'Hidden Bar' \
+  -configuration Debug CODE_SIGNING_ALLOWED=NO build
+
+# runnable local build (uses your Apple Development identity)
+xcodebuild -project 'Hidden Bar.xcodeproj' -scheme 'Hidden Bar' \
+  -configuration Debug build
+```
+
+Both must exit 0 with **no** `MACOSX_DEPLOYMENT_TARGET` override; the floor is
+13.0 in the project file. The single expected warning is the deliberately
+deprecated `SMLoginItemSetEnabled(false)` call that cleans up legacy installs.
+
+## Behavioral verification (no test target exists; this is the methodology)
+
+The repo has no unit-test infrastructure; behavior is verified against the real
+menu bar. Two building blocks make that scriptable:
+
+1. **Truth signal**: the separator's AX size.
+   `osascript -e 'tell application "System Events" to tell process "Hidden Bar" to get size of menu bar item 2 of menu bar 2'`
+   reads ~20pt expanded vs ~2x-screen-width collapsed. Item 1 is the arrow.
+2. **Real clicks, not AXPress**: `AXPress` on the arrow is a no-op because the
+   action handler reads `NSApp.currentEvent` (nil under assistive synthesis;
+   known accessibility defect). Post real `CGEvent` mouse clicks at the arrow's
+   AX-reported coordinates instead.
+
+Standard checks before any release:
+
+- expand/collapse toggle flips the separator size both ways;
+- with `numberOfSecondForAutoHide` set to 3, an expanded bar survives 2x the
+  window while the pointer is parked in the menubar band, collapses within the
+  window once the pointer leaves, and collapses normally if the pointer never
+  entered;
+- `hoverToExpand` off: no monitor log line, hover does nothing; on: dwell
+  expands (synthesize a `mouseMoved` stream: cursor warping alone fires no
+  events);
+- autostart pref on -> `AutoStart: SMAppService.mainApp.status = 1` on stderr;
+  off -> `= 0` (run the binary directly to capture stderr);
+- localization tables stay parseable: `plutil -lint hidden/*.lproj/*.strings`.
+
+When testing on a machine that runs Hidden Bar daily: export the prefs domain
+first (`defaults export com.dwarvesv.minimalbar backup.plist`), quit the
+installed app, test the dev build, then re-import and relaunch.
+
+## Release
+
+1. Verify the stack: every PR reviewed, builds green, behavioral checks above run.
+2. Bump `MARKETING_VERSION` (both Hidden Bar configurations) and
+   `CURRENT_PROJECT_VERSION` in the project file.
+3. Archive + notarize (Developer ID), staple, zip, GitHub release with notes
+   listing closed issues.
+4. App Store (separate lane): the MAS listing has lagged GitHub since v1.8
+   (issues #281/#202); decide deliberately whether a release goes there too.
+5. Homebrew cask (`brew install --cask hiddenbar`) follows the GitHub release
+   artifact; notarization matters (issue #219).
+6. Before any public release after the SMAppService migration: one
+   upgrade-path run from a launcher-era build (v1.9 or older) verifying System
+   Settings shows no ghost LauncherApplication login item.
+
+## Stacked-PR hygiene
+
+Feature stacks land as chained PRs (`develop <- A <- B`). Merge the base PR
+first, then retarget the next PR's base to `develop` BEFORE merging it;
+deleting a merged branch auto-closes dependents otherwise.
+
+## Issue triage map
+
+The live clusters and their code areas are documented at the end of
+[ARCHITECTURE.md](ARCHITECTURE.md#known-architectural-limits): notch, macOS 27
+mechanism break, and pointer-vs-open-menu limits. Memory reports (#361 et al.)
+have so far not reproduced as leaks (constraint-leak fix landed; `leaks` clean
+over toggle stress); re-check with a 24h+ uptime `footprint` sample before
+chasing further.


### PR DESCRIPTION
## What (stacked on #363, which stacks on #362)

Operating documentation for the modernized app, wired into the README:

- **docs/ARCHITECTURE.md**: how the length-inflation trick actually works, status-item topology (mermaid), the behavior layers (auto-hide deferral, opt-in hover-to-expand, self-restore), the SMAppService autostart path, security posture, and an honest list of architectural limits (notch, macOS 27 menu-bar re-architecture, open-menu detection)
- **docs/MANUAL.md**: every setting including the Terminal-only ones (`hoverToExpand`, arbitrary auto-hide delay, `AppleLanguages`), free behaviors, troubleshooting table
- **docs/RUNBOOK.md**: build commands, the AX-size-based behavioral verification methodology (no test target exists; this is how behavior gets proven), release sequence, stacked-PR hygiene

## Quality gates

- Every checkable claim verified against the live code by an adversarial doc-vs-code pass; 3 inaccuracies caught and fixed pre-commit
- A full-tree security audit accompanied this batch: verdict SECURE, 9/10; the four hygiene-level findings (pin HotKey to exactVersion, drop an unused entitlement, delete dead EventMonitor.swift, remove a debug KVO override) are queued as a separate small code PR since this branch is docs-only

## Merge order

#362 -> #363 -> this. Retarget before merging parents (branch deletion auto-closes dependents).