### PR TITLE
fix: degrade when macOS 27 cannot hide menu bar items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Multi-display: the collapse width is now sized for the widest attached screen, so icons no longer leak on wider external monitors; the width re-applies on display hot-plug.
 - Auto-collapse no longer fires while you are interacting with the menu bar (the timer defers and re-arms while the pointer is in the bar).
 - The Preferences window no longer closes when auto-collapse fires with "use full menu bar on expanding" enabled (#170, #66, #151).
+- macOS 27: Hidden Bar now detects when separator-length inflation no longer displaces menu-bar items and restores expanded state instead of staying fake-collapsed (#360).
 - Status items that were dragged off the bar are restored at launch instead of leaving the app unreachable.
 - Fixed constraint and observer leaks in the tutorial view rebuild.
 - Tutorial strings and F-key shortcut labels now render correctly (no more private-use glyphs).
@@ -22,5 +23,5 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Pinned the HotKey dependency to an exact version and removed an unused file-access entitlement and dead code (no behavior change).
 
 ### Known / in progress
-- macOS 27: the hide mechanism (separator-length inflation) can stop working on the re-architected menu bar (#360). This build adds diagnostics to characterize the failure; the graceful-degrade behavior and the longer-term managed-overflow redesign are tracked separately.
+- macOS 27: the re-architected menu bar still needs a different hiding mechanism; the longer-term managed-overflow redesign is tracked separately (#360/#366).
 - New menu-bar icons can appear in the hidden zone because macOS inserts them at the far left; ⌘-drag them to the right of the separator (see the manual). A built-in pin is part of the planned redesign.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Multi-display: the collapse width is now sized for the widest attached screen, so icons no longer leak on wider external monitors; the width re-applies on display hot-plug.
 - Auto-collapse no longer fires while you are interacting with the menu bar (the timer defers and re-arms while the pointer is in the bar).
 - The Preferences window no longer closes when auto-collapse fires with "use full menu bar on expanding" enabled (#170, #66, #151).
-- macOS 27: Hidden Bar now detects when separator-length inflation no longer displaces menu-bar items and restores expanded state instead of staying fake-collapsed (#360).
+- macOS 27: Hidden Bar now detects when separator-length inflation no longer displaces menu-bar items, restores expanded state instead of staying fake-collapsed, and keeps Preferences reachable from the arrow (#360).
 - Status items that were dragged off the bar are restored at launch instead of leaving the app unreachable.
 - Fixed constraint and observer leaks in the tutorial view rebuild.
 - Tutorial strings and F-key shortcut labels now render correctly (no more private-use glyphs).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,8 +98,10 @@ A full-tree audit (2026-06) scored 9/10 with hygiene-level findings only.
   trick cannot reveal them there. The real fix is a spillover/second-bar design
   (tracked in issues #357/#341/#148; candidate implementations in PRs #350/#358).
 - **macOS 27**: the menu bar re-architecture in macOS 27 betas
-  (`NSMenuBarNavigationSceneExtension`) breaks length-inflation hiding entirely
-  (issue #360). A different mechanism may be required.
+  (`NSMenuBarNavigationSceneExtension`) lets the separator grow without moving
+  neighboring status items, so length-inflation no longer hides icons. The app
+  detects that state and degrades to expanded mode; a different mechanism is
+  still required for real hiding (issue #360/#366).
 - **Other apps' open menus**: interaction-awareness is pointer-position-based;
   a pointer deep inside another app's open dropdown is below the menubar band,
   so the collapse can still fire there.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -9,25 +9,15 @@ Source of the current state: the v1.11 issue-clearing pass (2026-06-12), branch
 `fix/v1-11-batch` / draft PR #365, and SPEC-003. Core-model changes (separator length
 math, collapse state machine) are HIGH RISK and require a mandatory review-team pass.
 
-## Blocked on macOS 27 hardware (Han UAT)
+## macOS 27 follow-up
 
-- **macOS 27 hide-mechanism capture (#360).** Run the v1.11 build on real macOS 27,
-  trigger a collapse, capture the `HideMechanism:` NSLog (requested length / host-window
-  width / button width / actual length). This is the unblocker: it reveals which geometry
-  signal separates "honored" from "ignored" on 27. Diagnostic-only instrument already
-  shipped. See SPEC-003 + `StatusBarController.swift` (collapse path).
-- **Redesign the detection signal, then ship Option B (detect-and-degrade).** Review-team
-  found `btnSeparate.button?.window?.frame.width` reads the full menu-bar window width
-  (~1728pt on 26.5), so `honored` is trivially true on every OS. Switch to a positional
-  signal (separator button X-coordinate before vs after collapse). Once the 27 capture
-  calibrates it: re-add the one-shot post-collapse check, a one-time context-menu notice
-  linking #360, and stop re-inflating on confirmed failure. Depends on the capture above.
-- **Fix the 3 review bugs when re-enabling degrade.** (1) move the `hideMechanismChecked`
-  latch to AFTER `honored` is measured (a transient nil window currently burns the
-  one-shot check); (2) drop the `?? requested` nil-fallback that latches detection moot;
-  (3) `degradeHideUnavailable()` must restore the app activation policy under
-  "use full menu bar on expanding", or the bar shows while the app stays `.accessory`.
-  `StatusBarController.swift:316,318,329`.
+- **macOS 27 hide-mechanism capture (#360).** Captured on 27.0 (26A5353q):
+  the separator window grows from 17pt to ~3472pt, but separator/arrow X
+  positions stay fixed. That proves length inflation no longer displaces other
+  status items. Detect-and-degrade is now implemented in `StatusBarController`.
+- **Managed-overflow / second-bar redesign remains the real fix.** The graceful
+  degradation prevents a broken fake-collapsed state, but real hiding on macOS
+  27 still needs the larger #366 mechanism decision.
 
 ## Blocked on external-display hardware
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -66,7 +66,7 @@ To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
 | Login item missing after denying it once | System Settings > General > Login Items: re-enable Hidden Bar, then toggle the pref off/on |
 | A ghost "LauncherApplication" login item from old versions | Launch the current version once; it deauthorizes the legacy item automatically |
 | App language stuck | See the `AppleLanguages` command above, or System Settings > General > Language & Region > Applications |
-| Nothing hides on a macOS 27 beta | Known (issue #360); the menu bar re-architecture broke the hiding mechanism, fix under investigation |
+| Nothing hides on a macOS 27 beta | Known (issue #360); Hidden Bar detects the broken mechanism and stays expanded until the managed-overflow redesign lands |
 | A new or just-updated app's icon shows up already hidden | Expected, see "Why new icons start hidden" below; ⌘-drag it to the right of the separator once |
 
 ### Why new icons start hidden

--- a/hidden/Extensions/NSWindow+Extension.swift
+++ b/hidden/Extensions/NSWindow+Extension.swift
@@ -11,7 +11,7 @@ import AppKit
 extension NSWindow {
     func bringToFront() {
         self.makeKeyAndOrderFront(nil)
+        self.orderFrontRegardless()
         NSApp.activate(ignoringOtherApps: true)
     }
 }
-

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -76,6 +76,7 @@ class StatusBarController {
     private var hideMechanismChecked = false
     private var isHideMechanismUnavailable = false
     private let hideMechanismNoticeTag = 27360
+    private var contextMenu: NSMenu?
 
     private var hoverMonitor: Any?
     private var hoverDwellTimer: Timer?
@@ -234,10 +235,12 @@ class StatusBarController {
     }
 
     private func setupUI() {
+        btnSeparate.length = btnHiddenLength
         if let button = btnSeparate.button {
             button.image = self.imgIconLine
         }
         let menu = self.getContextMenu()
+        contextMenu = menu
         btnSeparate.menu = menu
 
         updateAutoCollapseMenuTitle()
@@ -255,26 +258,36 @@ class StatusBarController {
     }
     
     @objc func btnExpandCollapsePressed(sender: NSStatusBarButton) {
-        if let event = NSApp.currentEvent {
-
-            let isOptionKeyPressed = event.modifierFlags.contains(NSEvent.ModifierFlags.option)
-
-            if event.type == NSEvent.EventType.leftMouseUp && !isOptionKeyPressed{
-                self.expandCollapseIfNeeded()
-            } else if event.type == NSEvent.EventType.rightMouseUp && !isOptionKeyPressed {
-                // Right-click opens the same context menu the separator has (#356),
-                // making settings reachable from the control everyone clicks.
-                // The separators/always-hidden toggle stays on option-click.
-                showContextMenu(from: sender)
+        guard let event = NSApp.currentEvent else {
+            if isHideMechanismUnavailable {
+                openPreferenceViewControllerIfNeeded()
             } else {
-                // Both option+left and option+right land here: separators toggle.
-                self.showHideSeparatorsAndAlwayHideArea()
+                expandCollapseIfNeeded()
             }
+            return
+        }
+
+        let isOptionKeyPressed = event.modifierFlags.contains(NSEvent.ModifierFlags.option)
+
+        if event.type == NSEvent.EventType.leftMouseUp && !isOptionKeyPressed{
+            if isHideMechanismUnavailable {
+                openPreferenceViewControllerIfNeeded()
+            } else {
+                self.expandCollapseIfNeeded()
+            }
+        } else if event.type == NSEvent.EventType.rightMouseUp && !isOptionKeyPressed {
+            // Right-click opens the same context menu the separator has (#356),
+            // making settings reachable from the control everyone clicks.
+            // The separators/always-hidden toggle stays on option-click.
+            showContextMenu(from: sender)
+        } else {
+            // Both option+left and option+right land here: separators toggle.
+            self.showHideSeparatorsAndAlwayHideArea()
         }
     }
 
     private func showContextMenu(from button: NSStatusBarButton) {
-        guard let menu = btnSeparate.menu else { return }
+        guard let menu = contextMenu else { return }
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.maxY + 5), in: button)
     }
     
@@ -409,6 +422,7 @@ class StatusBarController {
         isHideMechanismUnavailable = true
         restoreExpandedMenuBarState()
         addHideMechanismUnavailableNotice()
+        routeSeparatorClicksThroughAction()
 
         if Preferences.useFullStatusBarOnExpandEnabled {
             NSApp.setActivationPolicy(.regular)
@@ -418,8 +432,35 @@ class StatusBarController {
         NSLog("HideMechanism: unavailable on this macOS version; restored expanded state")
     }
 
+    private func routeSeparatorClicksThroughAction() {
+        btnSeparate.menu = nil
+        guard let button = btnSeparate.button else { return }
+        button.target = self
+        button.action = #selector(btnSeparatePressed(sender:))
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    @objc private func btnSeparatePressed(sender: NSStatusBarButton) {
+        guard let event = NSApp.currentEvent else {
+            openPreferenceViewControllerIfNeeded()
+            return
+        }
+
+        let isOptionKeyPressed = event.modifierFlags.contains(NSEvent.ModifierFlags.option)
+
+        if event.type == NSEvent.EventType.leftMouseUp && !isOptionKeyPressed && isHideMechanismUnavailable {
+            openPreferenceViewControllerIfNeeded()
+        } else if event.type == NSEvent.EventType.rightMouseUp && !isOptionKeyPressed {
+            showContextMenu(from: sender)
+        } else if isOptionKeyPressed {
+            showHideSeparatorsAndAlwayHideArea()
+        } else {
+            showContextMenu(from: sender)
+        }
+    }
+
     private func addHideMechanismUnavailableNotice() {
-        guard let menu = btnSeparate.menu,
+        guard let menu = contextMenu,
               menu.item(withTag: hideMechanismNoticeTag) == nil
         else { return }
 
@@ -465,7 +506,7 @@ class StatusBarController {
     }
     
     private func updateAutoCollapseMenuTitle() {
-        guard let toggleAutoHideItem = btnSeparate.menu?.item(withTag: 1) else { return }
+        guard let toggleAutoHideItem = contextMenu?.item(withTag: 1) else { return }
         if Preferences.isAutoHide {
             toggleAutoHideItem.title = "Disable Auto Collapse".localized
         } else {

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -64,17 +64,26 @@ class StatusBarController {
     private var isToggle = false
 
     // SPEC-003 (macOS 27 hide-mechanism). macOS 27 re-architected the menu bar so
-    // inflating the separator length may no longer push items off-screen (#360).
-    // This is DIAGNOSTIC ONLY: on the first collapse with the menu-bar window
-    // ready, log the separator geometry so a macOS 27 run reveals which signal
-    // (if any) distinguishes "length honored" from "ignored". No behavior change.
-    // The degrade ACTION is deliberately NOT shipped: review found the trigger
-    // unverifiable without 27 hardware, and a false positive would disable hiding
-    // for a working user. The action lands once this log calibrates the signal.
+    // inflating the separator length no longer pushes other status items
+    // off-screen (#360). The separator still grows, but its X position and
+    // neighboring items no longer move with it.
+    private struct HideMechanismGeometry {
+        let separatorMinX: CGFloat
+        let separatorWidth: CGFloat
+        let arrowMinX: CGFloat
+    }
+
     private var hideMechanismChecked = false
+    private var isHideMechanismUnavailable = false
+    private let hideMechanismNoticeTag = 27360
 
     private var hoverMonitor: Any?
     private var hoverDwellTimer: Timer?
+
+    private var needsHideMechanismVerification: Bool {
+        ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27
+            && ProcessInfo.processInfo.environment["HIDDENBAR_DIAG"] == nil
+    }
 
     // True while the pointer sits in any screen's menubar band (the strip between
     // visibleFrame.maxY and frame.maxY, which is the menubar's exact height there).
@@ -110,9 +119,48 @@ class StatusBarController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             self?.collapseMenuBar()
         }
-        
+
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
+
+        if ProcessInfo.processInfo.environment["HIDDENBAR_DIAG"] != nil {
+            runHideMechanismDiagnostic()
+        }
+    }
+
+    // SPEC-003 / #360 capture. Self-triggering geometry probe, gated behind the
+    // HIDDENBAR_DIAG env var so it never runs for normal users. Waits for the
+    // status-item windows to exist, logs the EXPANDED geometry, forces a collapse,
+    // then logs the COLLAPSED geometry. On macOS 27, the width grows while the
+    // X positions stay fixed, so the old layout-displacement trick is unavailable.
+    private func runHideMechanismDiagnostic() {
+        func geom(_ label: String) {
+            let sepW = btnSeparate.button?.window?.frame.width ?? -1
+            let sepX = btnSeparate.button?.window?.frame.minX ?? -1
+            let arrW = btnExpandCollapse.button?.window?.frame.width ?? -1
+            let arrX = btnExpandCollapse.button?.window?.frame.minX ?? -1
+            NSLog("DIAG[\(label)]: separate.length=\(btnSeparate.length) requestedCollapse=\(btnHiddenCollapseLength) sepWinW=\(sepW) sepWinX=\(sepX) arrWinW=\(arrW) arrWinX=\(arrX) isCollapsed=\(isCollapsed)")
+        }
+        // Retry until the backing windows are up (they are nil right after launch).
+        func attempt(_ tries: Int) {
+            guard tries > 0 else { NSLog("DIAG: gave up waiting for status-item window"); return }
+            guard btnSeparate.button?.window != nil, btnExpandCollapse.button?.window != nil else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { attempt(tries - 1) }
+                return
+            }
+            let screens = NSScreen.screens.map { "\($0.frame.width)x\($0.frame.height)" }.joined(separator: ",")
+            NSLog("DIAG: macOS=\(ProcessInfo.processInfo.operatingSystemVersionString) screens=[\(screens)]")
+            // Ensure expanded baseline, measure, collapse, measure.
+            if isCollapsed { expandMenubar() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                geom("expanded")
+                self.btnSeparate.length = self.btnHiddenCollapseLength
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    geom("collapsed")
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { attempt(10) }
     }
     
     deinit {
@@ -152,6 +200,10 @@ class StatusBarController {
         // display hot-plug leaves the separator at a stale length (PR #354).
         let wasCollapsed = isCollapsed
         updateCollapsedLengths()
+        if isHideMechanismUnavailable {
+            restoreExpandedMenuBarState()
+            return
+        }
         if wasCollapsed {
             btnSeparate.length = btnHiddenCollapseLength
             if Preferences.areSeparatorsHidden {
@@ -249,6 +301,10 @@ class StatusBarController {
         if !self.isCollapsed {
             self.btnSeparate.length = self.btnHiddenLength
         }
+        guard !isHideMechanismUnavailable else {
+            self.btnAlwaysHidden?.length = self.btnAlwaysHiddenLength
+            return
+        }
         self.btnAlwaysHidden?.length = self.btnAlwaysHiddenEnableExpandCollapseLength
     }
     
@@ -263,11 +319,16 @@ class StatusBarController {
     }
     
     private func collapseMenuBar() {
+        guard !isHideMechanismUnavailable else {
+            addHideMechanismUnavailableNotice()
+            return
+        }
         guard self.isBtnSeparateValidPosition && !self.isCollapsed else {
             autoCollapseIfNeeded()
             return
         }
 
+        let before = hideMechanismGeometry()
         btnSeparate.length = self.btnHiddenCollapseLength
         if let button = btnExpandCollapse.button {
             button.image = Assets.expandImage
@@ -276,14 +337,11 @@ class StatusBarController {
             NSApp.setActivationPolicy(.accessory)
             NSApp.deactivate()
         }
-        verifyHideMechanismIfNeeded()
+        verifyHideMechanismIfNeeded(before: before)
     }
     private func expandMenubar() {
         guard self.isCollapsed else {return}
-        btnSeparate.length = btnHiddenLength
-        if let button = btnExpandCollapse.button {
-            button.image = Assets.collapseImage
-        }
+        restoreExpandedMenuBarState()
         autoCollapseIfNeeded()
         
         if Preferences.useFullStatusBarOnExpandEnabled {
@@ -300,30 +358,75 @@ class StatusBarController {
         startTimerToAutoHide()
     }
 
-    // After a collapse, confirm on the next runloop tick (so layout settles) that
-    // the separator actually claimed its inflated width. macOS <= 26 honors it;
-    // a macOS that ignores NSStatusItem.length leaves the slot narrow, meaning
-    // hiding did nothing. Checked once: cheap, and the OS behavior won't change
-    // mid-session.
-    private func verifyHideMechanismIfNeeded() {
-        guard !hideMechanismChecked else { return }
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self, self.isCollapsed else { return }
-            // Need the separator's backing window to measure. If it is not up yet
-            // (early launch), do NOT burn the one-shot check: return and let a
-            // later collapse retry once the window exists.
-            guard let separatorButton = self.btnSeparate.button,
-                  let window = separatorButton.window else { return }
-            self.hideMechanismChecked = true
-            // Log several geometry signals. On macOS <= 26 the inflation is
-            // honored; on macOS 27 it may be ignored. Which of these tracks the
-            // requested length is exactly what a 27 capture must reveal before any
-            // degrade action can trigger on a sound signal.
-            let requested = self.btnHiddenCollapseLength
-            let windowWidth = window.frame.width
-            let buttonWidth = separatorButton.frame.width
-            NSLog("HideMechanism: requested=\(requested) windowWidth=\(windowWidth) buttonWidth=\(buttonWidth) length=\(self.btnSeparate.length)")
+    private func restoreExpandedMenuBarState() {
+        btnSeparate.length = btnHiddenLength
+        btnAlwaysHidden?.length = btnAlwaysHiddenLength
+        if let button = btnExpandCollapse.button {
+            button.image = Assets.collapseImage
         }
+    }
+
+    private func hideMechanismGeometry() -> HideMechanismGeometry? {
+        guard
+            let separatorWindow = btnSeparate.button?.window,
+            let arrowWindow = btnExpandCollapse.button?.window
+        else { return nil }
+
+        return HideMechanismGeometry(
+            separatorMinX: separatorWindow.frame.minX,
+            separatorWidth: separatorWindow.frame.width,
+            arrowMinX: arrowWindow.frame.minX
+        )
+    }
+
+    // After a collapse, confirm that the inflated separator still participates
+    // in menu-bar layout. On macOS 27 it grows in place, so neighboring items do
+    // not move and hiding is unavailable.
+    private func verifyHideMechanismIfNeeded(before: HideMechanismGeometry?) {
+        guard needsHideMechanismVerification, !hideMechanismChecked else { return }
+        guard let before = before else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            guard let self = self, self.isCollapsed else { return }
+            guard let after = self.hideMechanismGeometry() else { return }
+
+            self.hideMechanismChecked = true
+            let requested = self.btnHiddenCollapseLength
+            let separatorShift = abs(after.separatorMinX - before.separatorMinX)
+            let arrowShift = abs(after.arrowMinX - before.arrowMinX)
+            let requiredShift = min(100, requested * 0.1)
+            let didDisplaceItems = max(separatorShift, arrowShift) >= requiredShift
+
+            NSLog("HideMechanism: requested=\(requested) beforeSepX=\(before.separatorMinX) afterSepX=\(after.separatorMinX) beforeArrowX=\(before.arrowMinX) afterArrowX=\(after.arrowMinX) afterSepWidth=\(after.separatorWidth) displaced=\(didDisplaceItems)")
+
+            if !didDisplaceItems {
+                self.markHideMechanismUnavailable()
+            }
+        }
+    }
+
+    private func markHideMechanismUnavailable() {
+        isHideMechanismUnavailable = true
+        restoreExpandedMenuBarState()
+        addHideMechanismUnavailableNotice()
+
+        if Preferences.useFullStatusBarOnExpandEnabled {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        NSLog("HideMechanism: unavailable on this macOS version; restored expanded state")
+    }
+
+    private func addHideMechanismUnavailableNotice() {
+        guard let menu = btnSeparate.menu,
+              menu.item(withTag: hideMechanismNoticeTag) == nil
+        else { return }
+
+        let item = NSMenuItem(title: "Hiding is unavailable on this macOS version", action: nil, keyEquivalent: "")
+        item.tag = hideMechanismNoticeTag
+        item.isEnabled = false
+        menu.insertItem(item, at: min(2, menu.numberOfItems))
     }
     
     private func startTimerToAutoHide() {


### PR DESCRIPTION
## Summary
On macOS 27, Hidden Bar now detects when separator inflation no longer moves neighboring menu-bar items and restores the expanded state instead of staying in a broken fake-collapsed state.

The captured behavior on 27.0 (26A5353q) showed the separator window growing from 17pt to ~3472pt while the separator and arrow X positions stayed fixed, which means the old length-inflation trick still creates a wide surface but no longer participates in menu-bar layout. This PR keeps the diagnostic path available, adds a one-shot positional verification on macOS 27+, and surfaces a quiet context-menu notice when real hiding is unavailable.

Refs dwarvesf/hidden#360.

## Validation
- `xcodebuild -project 'Hidden Bar.xcodeproj' -scheme 'Hidden Bar' -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `plutil -lint hidden/*.lproj/*.strings`
- Live macOS 27 smoke test: logged `displaced=false`, restored expanded state, and returned the separator to normal width (`22 x 24`).
- `HIDDENBAR_DIAG=1` still emits raw geometry without triggering degradation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
