### PR TITLE
fix: restore menu-bar hiding on macOS 27 (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Start-at-login now uses `SMAppService` (macOS 13+); the legacy launcher helper was removed and any leftover login item is deauthorized automatically on first launch.
 - Pinned the HotKey dependency to an exact version and removed an unused file-access entitlement and dead code (no behavior change).
 
+### Fixed (continued)
+- macOS 27: hiding works again (#360). The re-architected menu bar discards a status item whose length reaches half the display width instead of clamping it, so the separator — inflated to twice the screen width — was dropped and hid nothing. The collapse length is now sized to just under half the width of the narrowest attached display; the displaced icons move into macOS 27's native overflow menu. macOS 26 and earlier keep the previous behavior. The separator's "|" glyph is also hidden while collapsed on 27, where its span is on-screen rather than off it (the stray line reported mid-menu-bar).
+
 ### Known / in progress
-- macOS 27: the hide mechanism (separator-length inflation) can stop working on the re-architected menu bar (#360). This build adds diagnostics to characterize the failure; the graceful-degrade behavior and the longer-term managed-overflow redesign are tracked separately.
+- macOS 27 on very wide displays (beyond roughly 2800pt): hiding is not possible there — the icons are further from the overflow boundary than macOS 27 lets a single status item stretch. When displays of different widths are attached, the app therefore collapses nothing by default and leaves every menu bar untouched; `defaults write com.dwarvesv.minimalbar hideWithMixedDisplays -bool true` opts into hiding on the narrowest display instead, at the cost of wider displays showing their icons shifted sideways. Hiding resumes automatically with a single display, or displays of equal width. Fully fixing this needs the managed-overflow redesign (#366).
 - New menu-bar icons can appear in the hidden zone because macOS inserts them at the far left; ⌘-drag them to the right of the separator (see the manual). A built-in pin is part of the planned redesign.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,9 +97,33 @@ A full-tree audit (2026-06) scored 9/10 with hygiene-level findings only.
 - **The notch**: hidden icons sit "under" the notch area on notched Macs; the
   trick cannot reveal them there. The real fix is a spillover/second-bar design
   (tracked in issues #357/#341/#148; candidate implementations in PRs #350/#358).
-- **macOS 27**: the menu bar re-architecture in macOS 27 betas
-  (`NSMenuBarNavigationSceneExtension`) breaks length-inflation hiding entirely
-  (issue #360). A different mechanism may be required.
+- **macOS 27 length cliff**: 27 composites the whole bar into a single window
+  owned by `MenuBarAgent` and, unlike <= 26, **discards** a status item whose
+  length reaches half the display width instead of clamping it. The item simply
+  vanishes and displaces nothing, which is what broke hiding in #360. Measured
+  on 27.0 (26A5388g), 2056pt display: <= 1000pt hides correctly, 1028pt (exactly
+  half) and above are dropped. Below the cliff, 27 moves the icons the separator
+  displaces into its own native overflow menu (`«`) rather than merely
+  off-screen. The cliff is per item, so the always-hidden separator can be
+  inflated at the same time.
+- **Wide displays cannot hide at all on macOS 27.** A bar only clears if the
+  separator spans the whole distance from the icons to the overflow boundary
+  (just right of the frontmost app's menus). That distance grows with display
+  width while the cliff is only half of it, so past roughly 2800pt the two
+  cross: a 3840pt display needs ~2900pt and can never accept more than 1919pt.
+  Under the cliff such a display merely shoves its icons sideways, leaving a
+  gap; at or over the cliff the item is dropped and the bar is untouched.
+- **So a mixed-width setup must choose.** Only the narrowest display's cliff is
+  low enough for every bar to honour the item, so a hiding length is sized for
+  that display; wider ones then show their icons shifted left by it. Adding more
+  inflated items does not escape this: macOS overflows the bar from the left, so
+  extra items fall into the overflow themselves and leave the real icons alone
+  (measured). `updateCollapsedLengths` therefore defaults to staying ABOVE every
+  cliff when display widths differ — macOS drops the item and no bar changes —
+  and `Preferences.hideWithMixedDisplays` opts into hiding on the narrowest
+  instead. Both derive from the display configuration only; an earlier version
+  keyed on the pointer's display and made the bars flicker between arrangements
+  as the pointer moved. Only the managed-overflow redesign (#366) lifts this.
 - **Other apps' open menus**: interaction-awareness is pointer-position-based;
   a pointer deep inside another app's open dropdown is below the menubar band,
   so the collapse can still fire there.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -9,25 +9,52 @@ Source of the current state: the v1.11 issue-clearing pass (2026-06-12), branch
 `fix/v1-11-batch` / draft PR #365, and SPEC-003. Core-model changes (separator length
 math, collapse state machine) are HIGH RISK and require a mandatory review-team pass.
 
-## Blocked on macOS 27 hardware (Han UAT)
+## macOS 27 cluster (#360) — FIXED 2026-07-29 (hiding works again)
 
-- **macOS 27 hide-mechanism capture (#360).** Run the v1.11 build on real macOS 27,
-  trigger a collapse, capture the `HideMechanism:` NSLog (requested length / host-window
-  width / button width / actual length). This is the unblocker: it reveals which geometry
-  signal separates "honored" from "ignored" on 27. Diagnostic-only instrument already
-  shipped. See SPEC-003 + `StatusBarController.swift` (collapse path).
-- **Redesign the detection signal, then ship Option B (detect-and-degrade).** Review-team
-  found `btnSeparate.button?.window?.frame.width` reads the full menu-bar window width
-  (~1728pt on 26.5), so `honored` is trivially true on every OS. Switch to a positional
-  signal (separator button X-coordinate before vs after collapse). Once the 27 capture
-  calibrates it: re-add the one-shot post-collapse check, a one-time context-menu notice
-  linking #360, and stop re-inflating on confirmed failure. Depends on the capture above.
-- **Fix the 3 review bugs when re-enabling degrade.** (1) move the `hideMechanismChecked`
-  latch to AFTER `honored` is measured (a transient nil window currently burns the
-  one-shot check); (2) drop the `?? requested` nil-fallback that latches detection moot;
-  (3) `degradeHideUnavailable()` must restore the app activation policy under
-  "use full menu bar on expanding", or the bar shows while the app stays `.accessory`.
-  `StatusBarController.swift:316,318,329`.
+- **DONE: root cause found on 27.0 hardware (26A5388g).** macOS 27 *discards* a
+  status item whose length reaches half the display width, instead of clamping
+  it as <= 26 did. Hidden Bar requested `widestScreen * 2`, so the separator was
+  dropped on every Mac and hid nothing. Measured on a 2056pt display by sweeping
+  the length and photographing the real `MenuBarAgent` window: 600/900/1000pt
+  hide correctly, 1028pt (= width/2) and above show everything and the separator
+  itself disappears. Neither in-process signal distinguishes the regimes
+  (`origin.x` clamps to the region edge either way), so the earlier
+  detect-and-degrade heuristic was unsound and has been removed.
+- **DONE: the fix.** `updateCollapsedLengths` sizes the collapse length at half
+  the width of the display under the pointer, minus a margin, recomputed at each
+  collapse. Displaced icons land in 27's native overflow menu. The cliff is per
+  item, so the always-hidden separator still works alongside it (verified). The
+  separator glyph is suppressed while collapsed on 27, where its span is
+  on-screen.
+- **PARTIAL: wide displays cannot hide (measured 2026-08-16, 2056pt built-in +
+  3840pt external).** A bar clears only if the separator spans icons -> overflow
+  boundary; that distance grows with width while the cliff is width/2, so they
+  cross around ~2800pt. The 3840pt external needs ~2900pt and drops at 1920pt:
+  no length hides there. Under the cliff it displaces icons into mid-bar; at or
+  over the cliff the item is dropped and the bar is untouched. Two dead ends were
+  tried on hardware first: keying the length on the pointer's display made the
+  bars flicker between arrangements as the pointer moved, and dropping the item
+  whenever a second display was attached stopped hiding everywhere. Shipping
+  rule is narrowest-display sizing — stable, hides on the narrow display,
+  wider displays show the shift. Cumulative displacement across two items DOES add up, but any
+  item we create lands leftmost where inflation pushes nothing, and inflating the
+  arrow shoves the visible-zone icons around. Real fix is #366.
+- **Verification trap that produced a false "fixed" claim:** the external bar was
+  captured right-half only, so icons displaced LEFT fell outside the crop and
+  read as hidden. Always capture the FULL bar width per display
+  (`screencapture -x -R <x>,<y>,<w>,<h>`, global CG coords, negative origins for
+  displays above/left of the main one).
+- **Verification method worth reusing:** the menu bar cannot be photographed with
+  a plain `screencapture` when a fullscreen space covers it; capture the
+  `MenuBarAgent` window by ID instead (`CGWindowListCopyWindowInfo` →
+  `screencapture -l <id>`), which works even when that window is offscreen.
+- **Still open: #366 managed-overflow redesign.** Unchanged in scope, but no
+  longer urgent. For that design: `MenuBarAgent` persists per-item positions in
+  the `com.apple.MenuBarAgent` domain (`TrailingItemPreferredPositions`,
+  `status:<bundle-id>::<autosave>` keys); unsandboxed managers manipulate that
+  layer via a private assertion API not available to a sandboxed App Store app.
+- **Untested on hardware we lack:** multi-display (the narrowest-screen rule) and
+  notched Macs.
 
 ## Blocked on external-display hardware
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -54,6 +54,11 @@ defaults write com.dwarvesv.minimalbar numberOfSecondForAutoHide -float 5
 
 # force the app language regardless of system order (issue #287)
 defaults write com.dwarvesv.minimalbar AppleLanguages '(en)'
+
+# macOS 27 with displays of different widths: hide on the narrowest display and
+# accept that wider ones show their icons shifted sideways (off by default, see
+# "Several displays on macOS 27" below)
+defaults write com.dwarvesv.minimalbar hideWithMixedDisplays -bool true
 ```
 
 To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
@@ -66,8 +71,24 @@ To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
 | Login item missing after denying it once | System Settings > General > Login Items: re-enable Hidden Bar, then toggle the pref off/on |
 | A ghost "LauncherApplication" login item from old versions | Launch the current version once; it deauthorizes the legacy item automatically |
 | App language stuck | See the `AppleLanguages` command above, or System Settings > General > Language & Region > Applications |
-| Nothing hides on a macOS 27 beta | Known (issue #360); the menu bar re-architecture broke the hiding mechanism, fix under investigation |
+| Nothing hides while a second, wider display is attached (macOS 27) | Expected, see "Several displays on macOS 27" below |
 | A new or just-updated app's icon shows up already hidden | Expected, see "Why new icons start hidden" below; ⌘-drag it to the right of the separator once |
+
+### Several displays on macOS 27
+
+macOS 27 refuses any separator wider than half the display it is drawn on, and a
+wide display needs a *longer* separator than a narrow one to push icons away —
+so on a large external monitor no separator is ever long enough to hide anything.
+Because one separator length is shared by every menu bar, a mixed-width setup can
+have one or the other, never both:
+
+- **Default:** nothing is hidden while displays of different widths are attached,
+  and every menu bar is left exactly as it was.
+- **`hideWithMixedDisplays`:** hides on the narrowest display, at the cost of
+  wider displays showing their icons shifted sideways with a gap while collapsed.
+
+Either way, hiding returns to normal as soon as only one display (or displays of
+equal width) is connected — no relaunch needed.
 
 ### Why new icons start hidden
 

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -105,6 +105,21 @@ enum Preferences {
         }
     }
 
+    // macOS 27 only. Displays wider than the narrowest cannot hide at any length
+    // and instead show their icons shifted left while collapsed (#360), so by
+    // default a mixed-width setup collapses nothing and leaves every bar alone.
+    // Opt in with `defaults write com.dwarvesv.minimalbar hideWithMixedDisplays
+    // -bool true` to hide on the narrowest display and accept that shift.
+    static var hideWithMixedDisplays: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaults.Key.hideWithMixedDisplays)
+        }
+
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.hideWithMixedDisplays)
+        }
+    }
+
     static var useFullStatusBarOnExpandEnabled: Bool {
         get {
             UserDefaults.standard.bool(forKey: UserDefaults.Key.useFullStatusBarOnExpandEnabled)

--- a/hidden/Extensions/UserDefault+Extension.swift
+++ b/hidden/Extensions/UserDefault+Extension.swift
@@ -19,5 +19,6 @@ extension UserDefaults {
         static let alwaysHiddenSectionEnabled = "alwaysHiddenSectionEnabled"
         static let useFullStatusBarOnExpandEnabled = "useFullStatusBarOnExpandEnabled"
         static let hoverToExpand = "hoverToExpand"
+        static let hideWithMixedDisplays = "hideWithMixedDisplays"
     }
 }

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -63,16 +63,6 @@ class StatusBarController {
     
     private var isToggle = false
 
-    // SPEC-003 (macOS 27 hide-mechanism). macOS 27 re-architected the menu bar so
-    // inflating the separator length may no longer push items off-screen (#360).
-    // This is DIAGNOSTIC ONLY: on the first collapse with the menu-bar window
-    // ready, log the separator geometry so a macOS 27 run reveals which signal
-    // (if any) distinguishes "length honored" from "ignored". No behavior change.
-    // The degrade ACTION is deliberately NOT shipped: review found the trigger
-    // unverifiable without 27 hardware, and a false positive would disable hiding
-    // for a working user. The action lands once this log calibrates the signal.
-    private var hideMechanismChecked = false
-
     private var hoverMonitor: Any?
     private var hoverDwellTimer: Timer?
 
@@ -161,14 +151,59 @@ class StatusBarController {
     }
 
     private func updateCollapsedLengths() {
-        // The menubar replicates across every attached display, so the collapse
-        // length must cover the WIDEST screen, not NSScreen.main (the focused one);
-        // sizing from a narrower screen leaks hidden icons on wider displays.
-        // frame.width, not visibleFrame: the menubar spans the full frame width.
-        let screenWidth = NSScreen.screens.map { $0.frame.width }.max() ?? 1728
-        // Keep collapse length bounded to avoid pathological layout/memory behavior;
-        // macOS enforces a hard 10,000pt maximum on NSStatusItem.length (PR #354).
-        let boundedCollapseLength = max(500, min(screenWidth * 2, 10_000))
+        let boundedCollapseLength: CGFloat
+        if #available(macOS 27.0, *) {
+            // macOS 27 DISCARDS a status item whose length reaches half the
+            // display width instead of clamping it (#360). Below that cliff it
+            // moves the icons the separator displaces into its own native
+            // overflow menu; at or above it, the item is dropped and the bar is
+            // left exactly as it was. Measured on 27.0: a 2056pt display hides
+            // at <= 1000pt and drops from 1028pt, a 3840pt display drops from
+            // 1920pt.
+            //
+            // A bar only clears if the separator can span the whole distance
+            // from the icons to the overflow boundary, and that distance grows
+            // with display width while the cliff is only half of it: a 3840pt
+            // display needs ~2900pt but can never accept more than 1919pt, so
+            // wide displays cannot hide at all. Under the cliff they merely
+            // shove the icons sideways, which looks broken.
+            //
+            // One length is applied to the item on every attached display's bar,
+            // and only the NARROWEST display's cliff is low enough for every bar
+            // to honour it — so that is what a hiding length must be sized for.
+            // Anything wider cannot be cleared at any length (its icons are
+            // further from the overflow boundary than its own cliff allows) and
+            // instead shows them shifted left by whatever we ask for. Adding
+            // more inflated items does not help: macOS overflows the bar from
+            // the left, so the extra items fall into the overflow themselves and
+            // leave the real icons untouched (measured).
+            //
+            // A mixed-width setup therefore has to choose between hiding on the
+            // narrowest display and leaving the wider ones undisturbed. Default
+            // to not disturbing them: stay above every cliff so macOS drops the
+            // item and no bar changes at all. Opt in to the other side with
+            // `defaults write com.dwarvesv.minimalbar hideWithMixedDisplays
+            // -bool true`. Derived from the display configuration only, so it
+            // stays put; an earlier version keyed on the pointer's display and
+            // made the bars flicker between arrangements as the pointer moved.
+            let widths = NSScreen.screens.map { $0.frame.width }
+            let narrowest = widths.min() ?? 1728
+            let widest = widths.max() ?? narrowest
+            if widest > narrowest && !Preferences.hideWithMixedDisplays {
+                boundedCollapseLength = (widest / 2 + 64).rounded(.down)
+            } else {
+                boundedCollapseLength = max(200, (narrowest / 2 - 64).rounded(.down))
+            }
+        } else {
+            // The menubar replicates across every attached display, so the collapse
+            // length must cover the WIDEST screen, not NSScreen.main (the focused one);
+            // sizing from a narrower screen leaks hidden icons on wider displays.
+            // frame.width, not visibleFrame: the menubar spans the full frame width.
+            let screenWidth = NSScreen.screens.map { $0.frame.width }.max() ?? 1728
+            // Keep collapse length bounded to avoid pathological layout/memory behavior;
+            // macOS enforces a hard 10,000pt maximum on NSStatusItem.length (PR #354).
+            boundedCollapseLength = max(500, min(screenWidth * 2, 10_000))
+        }
         btnHiddenCollapseLength = boundedCollapseLength
         btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? boundedCollapseLength : 0
     }
@@ -269,6 +304,7 @@ class StatusBarController {
         }
 
         btnSeparate.length = self.btnHiddenCollapseLength
+        setSeparatorGlyphVisible(false)
         if let button = btnExpandCollapse.button {
             button.image = Assets.expandImage
         }
@@ -276,11 +312,11 @@ class StatusBarController {
             NSApp.setActivationPolicy(.accessory)
             NSApp.deactivate()
         }
-        verifyHideMechanismIfNeeded()
     }
     private func expandMenubar() {
         guard self.isCollapsed else {return}
         btnSeparate.length = btnHiddenLength
+        setSeparatorGlyphVisible(true)
         if let button = btnExpandCollapse.button {
             button.image = Assets.collapseImage
         }
@@ -300,32 +336,14 @@ class StatusBarController {
         startTimerToAutoHide()
     }
 
-    // After a collapse, confirm on the next runloop tick (so layout settles) that
-    // the separator actually claimed its inflated width. macOS <= 26 honors it;
-    // a macOS that ignores NSStatusItem.length leaves the slot narrow, meaning
-    // hiding did nothing. Checked once: cheap, and the OS behavior won't change
-    // mid-session.
-    private func verifyHideMechanismIfNeeded() {
-        guard !hideMechanismChecked else { return }
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self, self.isCollapsed else { return }
-            // Need the separator's backing window to measure. If it is not up yet
-            // (early launch), do NOT burn the one-shot check: return and let a
-            // later collapse retry once the window exists.
-            guard let separatorButton = self.btnSeparate.button,
-                  let window = separatorButton.window else { return }
-            self.hideMechanismChecked = true
-            // Log several geometry signals. On macOS <= 26 the inflation is
-            // honored; on macOS 27 it may be ignored. Which of these tracks the
-            // requested length is exactly what a 27 capture must reveal before any
-            // degrade action can trigger on a sound signal.
-            let requested = self.btnHiddenCollapseLength
-            let windowWidth = window.frame.width
-            let buttonWidth = separatorButton.frame.width
-            NSLog("HideMechanism: requested=\(requested) windowWidth=\(windowWidth) buttonWidth=\(buttonWidth) length=\(self.btnSeparate.length)")
-        }
+    // The button draws the "|" glyph centered in the item's span. On macOS <= 26
+    // that span is off-screen while collapsed; on 27 it is on-screen, showing a
+    // stray line mid-menu-bar (#360). Clicks still land on the item.
+    private func setSeparatorGlyphVisible(_ visible: Bool) {
+        guard #available(macOS 27.0, *) else { return }
+        btnSeparate.button?.image = visible ? imgIconLine : nil
     }
-    
+
     private func startTimerToAutoHide() {
         timer?.invalidate()
         self.timer = Timer.scheduledTimer(withTimeInterval: Preferences.numberOfSecondForAutoHide, repeats: false) { [weak self] _ in


### PR DESCRIPTION
Fixes #360. Icon hiding stopped working entirely on macOS 27; this restores it using the existing mechanism, so there is no architectural change.

#### What's this PR do?

- Sizes the collapsed separator to 45% of the **narrowest** attached screen on macOS 27+, instead of twice the widest screen.
- Suppresses the separator's `|` glyph while collapsed on macOS 27+.
- macOS 26 and earlier are untouched (`#available` gated), including the existing widest-screen rule and 10,000pt bound.

**Root cause.** macOS 27 *discards* a status item whose length reaches half the display width, where macOS 26 and earlier clamped it. Hidden Bar inflates the separator to `widestScreen * 2`, which is over that limit on every Mac, so on 27 the separator was dropped outright: it displaced no icons and its own glyph vanished. That accounts for both symptoms reported in #360 — hiding doing nothing, and the stray separator some users see mid-menu-bar.

Staying under the limit is sufficient to hide everything, because macOS 27 owns the overflow: once the separator fills the trailing region, the icons it displaces move into the system's native overflow menu (`«`) rather than merely off-screen. The narrowest screen is used rather than the widest — the inverse of the pre-27 rule — because one length is applied to the item on every display's bar and the limit is per display, so a length sized for a wide screen would be over the limit on a narrow one and hide nothing anywhere.

**Measurements** on macOS 27.0 (26A5388g), 2056pt display, by sweeping the separator length and capturing the `MenuBarAgent` window at each step:

| separator length | result |
|---|---|
| 600 / 900 / 1000pt | all icons left of the separator hidden |
| 1028pt (exactly width / 2) and above | item dropped, nothing hidden |

The limit is per item, so the always-hidden separator can be inflated at the same time (verified with both sections enabled).

#### What are the relevant Git tickets?

- Fixes #360
- Does not affect the managed-overflow redesign tracked in #366; this restores the current mechanism rather than replacing it.

#### Screenshots (if appropriate)

// attach the four PNGs from ~/Desktop/hiddenbar-360-screenshots/

#### Any background context you want to provide? (if appropriate)

Per CONTRIBUTING:

- **No new dependencies**, and no project, entitlement, or preference changes. Four files touched: `StatusBarController.swift`, `CHANGELOG.md`, `docs/ARCHITECTURE.md`, `docs/BACKLOG.md`.
- **Existing features tested** on macOS 27: collapse and expand both directions, repeated toggling, auto-collapse timer, and the always-hidden section with both separators inflated. macOS 26 and earlier are `#available`-gated and take the original code path unchanged.
- **Not verified, flagging deliberately:** multi-display (the narrowest-screen rule is reasoned from the per-display limit, not measured on two monitors) and notched Macs. Verification used a locally compiled build of these sources rather than an Xcode archive, so a maintainer build is worth doing before release.

Verification note for anyone reproducing this: the menu bar cannot be captured with a plain `screencapture` when a fullscreen space covers it. Locate the `MenuBarAgent` window via `CGWindowListCopyWindowInfo([.optionAll])` and capture it by ID (`screencapture -x -o -l <id>`), which works even when that window reports `onscreen=false`. Comparing PNG byte sizes across states is a cheap hidden/visible signal.