### PR TITLE
fix: prevent multiple instances of Hidden Bar from running simultaneously

### DIFF
--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -27,11 +27,27 @@ class AppDelegate: NSObject, NSApplicationDelegate{
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        guard ensureSingleInstance() else { return }
         setupAutoStartApp()
         registerDefaultValues()
         setupHotKey()
         openPreferencesIfNeeded()
         detectLTRLang()
+    }
+
+    /// Hidden Bar is a menu bar utility with no visible window, so launching it a
+    /// second time looks like a no-op while silently spawning a duplicate instance.
+    /// If another instance with the same bundle ID is already running, activate it
+    /// and terminate this one instead.
+    private func ensureSingleInstance() -> Bool {
+        let current = ProcessInfo.processInfo.processIdentifier
+        let existing = NSWorkspace.shared.runningApplications.first {
+            $0.bundleIdentifier == Bundle.main.bundleIdentifier && $0.processIdentifier != current
+        }
+        guard let existing else { return true }
+        existing.activate(options: [.activateIgnoringOtherApps])
+        NSApp.terminate(nil)
+        return false
     }
     
     func openPreferencesIfNeeded() {


### PR DESCRIPTION
# What & Why

Hidden Bar is a menu bar utility with no visible window, so launching it a second time silently spawns a duplicate instance instead of switching to the one already running. That leaves two identical status bar items and two preference windows — confusing and wasteful.

This adds an early guard in `applicationDidFinishLaunching`:

- Scans `NSWorkspace.shared.runningApplications` for another instance with the same bundle ID (excluding the current process).
- If one is found, it activates the existing instance and terminates the new one.

# Changes

- `hidden/AppDelegate.swift`: `ensureSingleInstance()` guard + call in `applicationDidFinishLaunching` (16 lines added, one file).

# Testing

- Parses cleanly with `swiftc -parse`.
- Logic mirrors the standard macOS single-instance pattern for agent/menu bar apps (bundle-ID match + PID exclusion + activate/terminate).

Closes the intent of #376 (which was withdrawn — it targeted the stale `master` branch and lacked the actual code change).