### PR TITLE
fix: restore menu-bar hiding on macOS 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Right-clicking the expand/collapse arrow now opens the same context menu as the separator, so Preferences is reachable from the control you already click.
 
 ### Fixed
+- macOS 27: hiding works again. The re-architected menu bar discards a status
+  item whose length reaches half of a display's width; the separator now stays
+  below that threshold so displaced icons enter macOS's native overflow menu.
 - Multi-display: the collapse width is now sized for the widest attached screen, so icons no longer leak on wider external monitors; the width re-applies on display hot-plug.
 - Auto-collapse no longer fires while you are interacting with the menu bar (the timer defers and re-arms while the pointer is in the bar).
 - The Preferences window no longer closes when auto-collapse fires with "use full menu bar on expanding" enabled (#170, #66, #151).
@@ -22,5 +25,8 @@ Requires macOS 13 Ventura or later. (Pre-Ventura users: stay on
 - Pinned the HotKey dependency to an exact version and removed an unused file-access entitlement and dead code (no behavior change).
 
 ### Known / in progress
-- macOS 27: the hide mechanism (separator-length inflation) can stop working on the re-architected menu bar (#360). This build adds diagnostics to characterize the failure; the graceful-degrade behavior and the longer-term managed-overflow redesign are tracked separately.
+- macOS 27 with different-width displays: no single separator length can hide
+  every bar. The default leaves all bars unchanged; set
+  `hideWithMixedDisplays` to hide on the narrowest display, accepting shifted
+  icons on wider displays. A managed-overflow redesign remains tracked in #366.
 - New menu-bar icons can appear in the hidden zone because macOS inserts them at the far left; ⌘-drag them to the right of the separator (see the manual). A built-in pin is part of the planned redesign.

--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F85B23AA013100981CA5 /* SelectedSecond.swift */; };
 		08A5F85F23AA01EE00981CA5 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = 08A5F85E23AA01EE00981CA5 /* HotKey */; };
 		08A5F86123AA085B00981CA5 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F86023AA085B00981CA5 /* Preferences.swift */; };
+		A12700012700000127000001 /* CollapseLengthPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12700012700000127000002 /* CollapseLengthPolicy.swift */; };
 		08A5F86423AA09F300981CA5 /* UserDefault+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A5F86323AA09F300981CA5 /* UserDefault+Extension.swift */; };
 		08B9F32C2411883300AA0551 /* NSWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9F32B2411883300AA0551 /* NSWindow+Extension.swift */; };
 		08C20FDE23AABDD10035D978 /* HyperlinkTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FDD23AABDD10035D978 /* HyperlinkTextField.swift */; };
@@ -43,6 +44,7 @@
 		08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		08A5F85B23AA013100981CA5 /* SelectedSecond.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSecond.swift; sourceTree = "<group>"; };
 		08A5F86023AA085B00981CA5 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
+		A12700012700000127000002 /* CollapseLengthPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapseLengthPolicy.swift; sourceTree = "<group>"; };
 		08A5F86323AA09F300981CA5 /* UserDefault+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefault+Extension.swift"; sourceTree = "<group>"; };
 		08B9F32B2411883300AA0551 /* NSWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extension.swift"; sourceTree = "<group>"; };
 		08C20FDD23AABDD10035D978 /* HyperlinkTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperlinkTextField.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				92C97B87220032ED0007559C /* Util.swift */,
 				00117C4326600671005E517C /* Assets.swift */,
 				92C97B8E220147FE0007559C /* Constant.swift */,
+				A12700012700000127000002 /* CollapseLengthPolicy.swift */,
 				08A5F86023AA085B00981CA5 /* Preferences.swift */,
 			);
 			path = Common;
@@ -312,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A12700012700000127000001 /* CollapseLengthPolicy.swift in Sources */,
 				92C97B8F220147FE0007559C /* Constant.swift in Sources */,
 				08C20FE023AB44E60035D978 /* Bundle+Extension.swift in Sources */,
 				08A5F85C23AA013100981CA5 /* SelectedSecond.swift in Sources */,

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -54,6 +54,10 @@ defaults write com.dwarvesv.minimalbar numberOfSecondForAutoHide -float 5
 
 # force the app language regardless of system order (issue #287)
 defaults write com.dwarvesv.minimalbar AppleLanguages '(en)'
+
+# macOS 27 with displays of different widths: hide on the narrowest display
+# and accept shifted icons on wider displays (off by default)
+defaults write com.dwarvesv.minimalbar hideWithMixedDisplays -bool true
 ```
 
 To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
@@ -66,7 +70,7 @@ To undo any of them: `defaults delete com.dwarvesv.minimalbar <key>`.
 | Login item missing after denying it once | System Settings > General > Login Items: re-enable Hidden Bar, then toggle the pref off/on |
 | A ghost "LauncherApplication" login item from old versions | Launch the current version once; it deauthorizes the legacy item automatically |
 | App language stuck | See the `AppleLanguages` command above, or System Settings > General > Language & Region > Applications |
-| Nothing hides on a macOS 27 beta | Known (issue #360); the menu bar re-architecture broke the hiding mechanism, fix under investigation |
+| Nothing hides with different-width displays on macOS 27 | Expected by default; set `hideWithMixedDisplays` to hide on the narrowest display |
 | A new or just-updated app's icon shows up already hidden | Expected, see "Why new icons start hidden" below; ⌘-drag it to the right of the separator once |
 
 ### Why new icons start hidden

--- a/hidden/Common/CollapseLengthPolicy.swift
+++ b/hidden/Common/CollapseLengthPolicy.swift
@@ -1,0 +1,35 @@
+//
+//  CollapseLengthPolicy.swift
+//  Hidden Bar
+//
+
+import Foundation
+
+enum CollapseLengthPolicy {
+    private static let macOS27Margin = 64.0
+
+    static func collapsedLength(
+        screenWidths: [Double],
+        macOSMajorVersion: Int,
+        hideWithMixedDisplays: Bool = false
+    ) -> Double {
+        let widestScreenWidth = screenWidths.max() ?? 1728
+
+        guard macOSMajorVersion >= 27 else {
+            return max(500, min(widestScreenWidth * 2, 10_000))
+        }
+
+        // macOS 27 drops a status item at half the display width. Staying below
+        // that limit lets the system move the displaced icons into its overflow.
+        let narrowestScreenWidth = screenWidths.min() ?? widestScreenWidth
+        if widestScreenWidth > narrowestScreenWidth && !hideWithMixedDisplays {
+            // One NSStatusItem length is shared by all menu bars. On displays of
+            // different widths no one length can clear both bars, so make macOS
+            // discard it on every bar rather than visibly shifting icons on wider
+            // displays. Users can opt into hiding on the narrowest display.
+            return floor(widestScreenWidth / 2 + macOS27Margin)
+        }
+        let belowHalfWidthLimit = max(0, floor(narrowestScreenWidth / 2) - 1)
+        return min(max(200, floor(narrowestScreenWidth / 2 - macOS27Margin)), belowHalfWidthLimit)
+    }
+}

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -105,6 +105,16 @@ enum Preferences {
         }
     }
 
+    static var hideWithMixedDisplays: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaults.Key.hideWithMixedDisplays)
+        }
+
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.hideWithMixedDisplays)
+        }
+    }
+
     static var useFullStatusBarOnExpandEnabled: Bool {
         get {
             UserDefaults.standard.bool(forKey: UserDefaults.Key.useFullStatusBarOnExpandEnabled)

--- a/hidden/Extensions/UserDefault+Extension.swift
+++ b/hidden/Extensions/UserDefault+Extension.swift
@@ -19,5 +19,6 @@ extension UserDefaults {
         static let alwaysHiddenSectionEnabled = "alwaysHiddenSectionEnabled"
         static let useFullStatusBarOnExpandEnabled = "useFullStatusBarOnExpandEnabled"
         static let hoverToExpand = "hoverToExpand"
+        static let hideWithMixedDisplays = "hideWithMixedDisplays"
     }
 }

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -161,16 +161,14 @@ class StatusBarController {
     }
 
     private func updateCollapsedLengths() {
-        // The menubar replicates across every attached display, so the collapse
-        // length must cover the WIDEST screen, not NSScreen.main (the focused one);
-        // sizing from a narrower screen leaks hidden icons on wider displays.
-        // frame.width, not visibleFrame: the menubar spans the full frame width.
-        let screenWidth = NSScreen.screens.map { $0.frame.width }.max() ?? 1728
-        // Keep collapse length bounded to avoid pathological layout/memory behavior;
-        // macOS enforces a hard 10,000pt maximum on NSStatusItem.length (PR #354).
-        let boundedCollapseLength = max(500, min(screenWidth * 2, 10_000))
-        btnHiddenCollapseLength = boundedCollapseLength
-        btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? boundedCollapseLength : 0
+        let screenWidths = NSScreen.screens.map { Double($0.frame.width) }
+        let collapsedLength = CollapseLengthPolicy.collapsedLength(
+            screenWidths: screenWidths,
+            macOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+            hideWithMixedDisplays: Preferences.hideWithMixedDisplays
+        )
+        btnHiddenCollapseLength = CGFloat(collapsedLength)
+        btnAlwaysHiddenEnableExpandCollapseLength = Preferences.alwaysHiddenSectionEnabled ? CGFloat(collapsedLength) : 0
     }
     
     private func restoreRemovedStatusItems() {
@@ -269,6 +267,7 @@ class StatusBarController {
         }
 
         btnSeparate.length = self.btnHiddenCollapseLength
+        setSeparatorGlyphVisible(false)
         if let button = btnExpandCollapse.button {
             button.image = Assets.expandImage
         }
@@ -281,6 +280,7 @@ class StatusBarController {
     private func expandMenubar() {
         guard self.isCollapsed else {return}
         btnSeparate.length = btnHiddenLength
+        setSeparatorGlyphVisible(true)
         if let button = btnExpandCollapse.button {
             button.image = Assets.collapseImage
         }
@@ -324,6 +324,11 @@ class StatusBarController {
             let buttonWidth = separatorButton.frame.width
             NSLog("HideMechanism: requested=\(requested) windowWidth=\(windowWidth) buttonWidth=\(buttonWidth) length=\(self.btnSeparate.length)")
         }
+    }
+
+    private func setSeparatorGlyphVisible(_ visible: Bool) {
+        guard ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27 else { return }
+        btnSeparate.button?.image = visible ? imgIconLine : nil
     }
     
     private func startTimerToAutoHide() {

--- a/tests/CollapseLengthPolicyTests.swift
+++ b/tests/CollapseLengthPolicyTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+@main
+struct CollapseLengthPolicyTests {
+    static func expect(_ actual: Double, equals expected: Double, _ message: String) {
+        guard actual == expected else {
+            fatalError("\(message): expected \(expected), got \(actual)")
+        }
+    }
+
+    static func main() {
+        // macOS 27 discards a status item at half the display width. A single-display
+        // collapse must stay beneath that cliff while legacy systems preserve their
+        // existing oversized separator behavior.
+        expect(
+            CollapseLengthPolicy.collapsedLength(screenWidths: [1920], macOSMajorVersion: 27),
+            equals: 896,
+            "macOS 27 keeps the separator below half the display width"
+        )
+
+        expect(
+            CollapseLengthPolicy.collapsedLength(screenWidths: [1920], macOSMajorVersion: 26),
+            equals: 3840,
+            "macOS 26 retains the existing collapse length"
+        )
+
+        expect(
+            CollapseLengthPolicy.collapsedLength(screenWidths: [601], macOSMajorVersion: 27),
+            equals: 236,
+            "macOS 27 retains a usable lower bound on small displays"
+        )
+
+        expect(
+            CollapseLengthPolicy.collapsedLength(screenWidths: [100], macOSMajorVersion: 27),
+            equals: 49,
+            "macOS 27 never reaches the half-width discard threshold"
+        )
+
+        expect(
+            CollapseLengthPolicy.collapsedLength(screenWidths: [1920, 3440], macOSMajorVersion: 27),
+            equals: 1784,
+            "mixed displays remain unchanged by default"
+        )
+
+        expect(
+            CollapseLengthPolicy.collapsedLength(
+                screenWidths: [1920, 3440],
+                macOSMajorVersion: 27,
+                hideWithMixedDisplays: true
+            ),
+            equals: 896,
+            "mixed displays can opt into hiding on the narrowest display"
+        )
+
+        print("CollapseLengthPolicy tests passed")
+    }
+}

--- a/tests/run-collapse-length-policy-tests.sh
+++ b/tests/run-collapse-length-policy-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH= cd -- "$test_dir/.." && pwd)
+test_binary=$(mktemp -d)/collapse-length-policy-tests
+trap 'rm -rf "$(dirname -- "$test_binary")"' EXIT
+
+swiftc "$repo_dir/hidden/Common/CollapseLengthPolicy.swift" \
+  "$test_dir/CollapseLengthPolicyTests.swift" \
+  -o "$test_binary"
+"$test_binary"


### PR DESCRIPTION
## Summary
- keep the collapsed separator below macOS 27's half-screen discard threshold, allowing displaced items to enter the system overflow
- preserve the existing macOS 26-and-earlier behavior and avoid altering mixed-width displays by default; provide an opt-in for hiding on the narrowest display
- add a focused policy regression suite and document the new behavior

This independently validates the same root cause described in #382, with a small testable policy boundary and current-device verification.

## Test plan
- [x] `sh tests/run-collapse-length-policy-tests.sh`
- [x] `xcodebuild -project 'Hidden Bar.xcodeproj' -scheme 'Hidden Bar' -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- [x] `plutil -lint hidden/*.lproj/*.strings`
- [x] macOS 27 device test: click toggle produced separator widths `898 -> 22 -> 898`