### PR TITLE
feat: Notch Overflow — access menu bar icons hidden behind the camera notch (rebased, review feedback addressed)

### DIFF
--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4D8C4B09D62D4884B34E1A14 /* NotchOverflowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */; };
 		00117C4426600671005E517C /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00117C4326600671005E517C /* Assets.swift */; };
 		00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */; };
 		0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */; };
@@ -20,10 +19,14 @@
 		08C20FDE23AABDD10035D978 /* HyperlinkTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FDD23AABDD10035D978 /* HyperlinkTextField.swift */; };
 		08C20FE023AB44E60035D978 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FDF23AB44E60035D978 /* Bundle+Extension.swift */; };
 		08C20FE223AB452C0035D978 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FE123AB452C0035D978 /* AboutViewController.swift */; };
+		0C57EC38D13980EBF7C9BBDA /* NotchOverflowMenuBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3BF69BE15B7DE0272612470 /* NotchOverflowMenuBuilderTests.swift */; };
 		1A6C9D316FF97AF473765572 /* NotchGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B44EDBC1C09AEF89C472D74 /* NotchGeometryTests.swift */; };
 		3CF14C82221FA49D0083D42B /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF14C81221FA49D0083D42B /* PreferencesWindowController.swift */; };
+		4D8C4B09D62D4884B34E1A14 /* NotchOverflowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */; };
 		55F3F1192608923B0054B881 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3F1182608923B0054B881 /* Date+Extension.swift */; };
 		55F3F11D2608925A0054B881 /* StackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3F11C2608925A0054B881 /* StackView+Extension.swift */; };
+		70F996B8AD634F42175AE89C /* NotchOverflowPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06495EE4F823D325A44A357C /* NotchOverflowPreferencesTests.swift */; };
+		8557996B406181A91CBF5917 /* MenuBarExtraClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6D80CB37CBB7622AC8455D /* MenuBarExtraClassifierTests.swift */; };
 		929113F521F9D04100173149 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929113F421F9D04100173149 /* AppDelegate.swift */; };
 		929113F921F9D04200173149 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 929113F821F9D04200173149 /* Assets.xcassets */; };
 		929113FC21F9D04200173149 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 929113FA21F9D04200173149 /* Main.storyboard */; };
@@ -50,9 +53,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchOverflowController.swift; sourceTree = "<group>"; };
 		00117C4326600671005E517C /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
+		06495EE4F823D325A44A357C /* NotchOverflowPreferencesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotchOverflowPreferencesTests.swift; sourceTree = "<group>"; };
 		0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeybindingPreferences.swift; sourceTree = "<group>"; };
 		08A5F85923AA007A00981CA5 /* PreferencesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		08A5F85B23AA013100981CA5 /* SelectedSecond.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSecond.swift; sourceTree = "<group>"; };
@@ -73,6 +76,7 @@
 		55D9B6BD2661DEE8007AF073 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		55F3F1182608923B0054B881 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		55F3F11C2608925A0054B881 /* StackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StackView+Extension.swift"; sourceTree = "<group>"; };
+		6B6D80CB37CBB7622AC8455D /* MenuBarExtraClassifierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarExtraClassifierTests.swift; sourceTree = "<group>"; };
 		6F2F828CAAE82A4D34BDDCBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		9220587D22127050008A8B03 /* Hidden.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Hidden.entitlements; path = Hidden/Hidden.entitlements; sourceTree = "<group>"; };
 		929113F121F9D04100173149 /* Hidden Bar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hidden Bar.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -97,6 +101,8 @@
 		B1326445261D7E0200319D35 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B350A2CC23AAFB47003A04AC /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		B8404C9A24041A4300E6DBF8 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
+		BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchOverflowController.swift; sourceTree = "<group>"; };
+		E3BF69BE15B7DE0272612470 /* NotchOverflowMenuBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotchOverflowMenuBuilderTests.swift; sourceTree = "<group>"; };
 		FF57A44B25E6C50200988FC2 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FF8A0FB5265E10DB00C76226 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -143,14 +149,6 @@
 			path = Features;
 			sourceTree = "<group>";
 		};
-		905962CD99D24D0C893AFFA7 /* NotchOverflow */ = {
-			isa = PBXGroup;
-			children = (
-				BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */,
-			);
-			path = NotchOverflow;
-			sourceTree = "<group>";
-		};
 		0842CDFD23A9FF7500D14BD4 /* StatusBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -194,6 +192,9 @@
 			isa = PBXGroup;
 			children = (
 				9B44EDBC1C09AEF89C472D74 /* NotchGeometryTests.swift */,
+				6B6D80CB37CBB7622AC8455D /* MenuBarExtraClassifierTests.swift */,
+				E3BF69BE15B7DE0272612470 /* NotchOverflowMenuBuilderTests.swift */,
+				06495EE4F823D325A44A357C /* NotchOverflowPreferencesTests.swift */,
 			);
 			name = HiddenTests;
 			path = HiddenTests;
@@ -205,6 +206,14 @@
 				6F2F828CAAE82A4D34BDDCBB /* Cocoa.framework */,
 			);
 			name = "OS X";
+			sourceTree = "<group>";
+		};
+		905962CD99D24D0C893AFFA7 /* NotchOverflow */ = {
+			isa = PBXGroup;
+			children = (
+				BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */,
+			);
+			path = NotchOverflow;
 			sourceTree = "<group>";
 		};
 		9267D3212201A49200EFFCE2 /* Common */ = {
@@ -393,6 +402,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A6C9D316FF97AF473765572 /* NotchGeometryTests.swift in Sources */,
+				8557996B406181A91CBF5917 /* MenuBarExtraClassifierTests.swift in Sources */,
+				0C57EC38D13980EBF7C9BBDA /* NotchOverflowMenuBuilderTests.swift in Sources */,
+				70F996B8AD634F42175AE89C /* NotchOverflowPreferencesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D8C4B09D62D4884B34E1A14 /* NotchOverflowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */; };
 		00117C4426600671005E517C /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00117C4326600671005E517C /* Assets.swift */; };
 		00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */; };
 		0842CDFB23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */; };
@@ -49,6 +50,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchOverflowController.swift; sourceTree = "<group>"; };
 		00117C4326600671005E517C /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		00137CDE24A63DB1004AC855 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		0842CDFA23A9FDD000D14BD4 /* GlobalKeybindingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeybindingPreferences.swift; sourceTree = "<group>"; };
@@ -134,10 +136,19 @@
 			isa = PBXGroup;
 			children = (
 				08C20FDC23AABC440035D978 /* About */,
+				905962CD99D24D0C893AFFA7 /* NotchOverflow */,
 				0842CDFE23A9FF7C00D14BD4 /* Preferences */,
 				0842CDFD23A9FF7500D14BD4 /* StatusBar */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		905962CD99D24D0C893AFFA7 /* NotchOverflow */ = {
+			isa = PBXGroup;
+			children = (
+				BE73DB4E0664488997EEB6DE /* NotchOverflowController.swift */,
+			);
+			path = NotchOverflow;
 			sourceTree = "<group>";
 		};
 		0842CDFD23A9FF7500D14BD4 /* StatusBar */ = {
@@ -410,6 +421,7 @@
 				08C20FE223AB452C0035D978 /* AboutViewController.swift in Sources */,
 				00137CDF24A63DB1004AC855 /* Notification.Name+Extension.swift in Sources */,
 				08A5F86423AA09F300981CA5 /* UserDefault+Extension.swift in Sources */,
+				4D8C4B09D62D4884B34E1A14 /* NotchOverflowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hidden Bar.xcodeproj/project.pbxproj
+++ b/Hidden Bar.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		08C20FDE23AABDD10035D978 /* HyperlinkTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FDD23AABDD10035D978 /* HyperlinkTextField.swift */; };
 		08C20FE023AB44E60035D978 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FDF23AB44E60035D978 /* Bundle+Extension.swift */; };
 		08C20FE223AB452C0035D978 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C20FE123AB452C0035D978 /* AboutViewController.swift */; };
+		1A6C9D316FF97AF473765572 /* NotchGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B44EDBC1C09AEF89C472D74 /* NotchGeometryTests.swift */; };
 		3CF14C82221FA49D0083D42B /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF14C81221FA49D0083D42B /* PreferencesWindowController.swift */; };
 		55F3F1192608923B0054B881 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3F1182608923B0054B881 /* Date+Extension.swift */; };
 		55F3F11D2608925A0054B881 /* StackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F3F11C2608925A0054B881 /* StackView+Extension.swift */; };
@@ -34,7 +35,18 @@
 		92C97B9122018C1F0007559C /* StatusBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C97B9022018C1F0007559C /* StatusBarController.swift */; };
 		967F4B2524169BC800F18D3C /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F4B2424169BC800F18D3C /* String+Extension.swift */; };
 		967F4B2824169CAF00F18D3C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 967F4B2A24169CAF00F18D3C /* Localizable.strings */; };
+		9C79B5D97BC90E0174BC52BE /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F2F828CAAE82A4D34BDDCBB /* Cocoa.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1CD893E4132E5B9D9BBD5DFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 929113E921F9D04100173149 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 929113F021F9D04100173149;
+			remoteInfo = "Hidden Bar";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		00117C4326600671005E517C /* Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
@@ -59,6 +71,7 @@
 		55D9B6BD2661DEE8007AF073 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		55F3F1182608923B0054B881 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		55F3F11C2608925A0054B881 /* StackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StackView+Extension.swift"; sourceTree = "<group>"; };
+		6F2F828CAAE82A4D34BDDCBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		9220587D22127050008A8B03 /* Hidden.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Hidden.entitlements; path = Hidden/Hidden.entitlements; sourceTree = "<group>"; };
 		929113F121F9D04100173149 /* Hidden Bar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hidden Bar.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		929113F421F9D04100173149 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -76,6 +89,8 @@
 		967F4B2924169CAF00F18D3C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		967F4B2B24169CB200F18D3C /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		967F4B2C24169CB400F18D3C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9B44EDBC1C09AEF89C472D74 /* NotchGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotchGeometryTests.swift; path = NotchGeometryTests.swift; sourceTree = "<group>"; };
+		9C7BF2ECD52E3E5C0D8D7556 /* HiddenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HiddenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1326443261D7E0200319D35 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		B1326445261D7E0200319D35 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B350A2CC23AAFB47003A04AC /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
@@ -85,6 +100,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0A920B36E60886C7F0761422 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C79B5D97BC90E0174BC52BE /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		929113EE21F9D04100173149 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -156,6 +179,23 @@
 			path = About;
 			sourceTree = "<group>";
 		};
+		82028E09AB3D6FF759D8044C /* HiddenTests */ = {
+			isa = PBXGroup;
+			children = (
+				9B44EDBC1C09AEF89C472D74 /* NotchGeometryTests.swift */,
+			);
+			name = HiddenTests;
+			path = HiddenTests;
+			sourceTree = "<group>";
+		};
+		8E00063F190C5A30FD3DA5BA /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				6F2F828CAAE82A4D34BDDCBB /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 		9267D3212201A49200EFFCE2 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -174,6 +214,7 @@
 				929113F321F9D04100173149 /* hidden */,
 				929113F221F9D04100173149 /* Products */,
 				92C5057D21FEC24C0084719A /* Frameworks */,
+				82028E09AB3D6FF759D8044C /* HiddenTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -181,6 +222,7 @@
 			isa = PBXGroup;
 			children = (
 				929113F121F9D04100173149 /* Hidden Bar.app */,
+				9C7BF2ECD52E3E5C0D8D7556 /* HiddenTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -207,6 +249,7 @@
 			children = (
 				92C5058021FEC2590084719A /* Cocoa.framework */,
 				92C5057E21FEC24C0084719A /* ServiceManagement.framework */,
+				8E00063F190C5A30FD3DA5BA /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -243,6 +286,24 @@
 			productName = vanillaClone;
 			productReference = 929113F121F9D04100173149 /* Hidden Bar.app */;
 			productType = "com.apple.product-type.application";
+		};
+		B6ED1C7FB7AE7D98FD4143B2 /* HiddenTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 655BFC0A8D76007E8D584889 /* Build configuration list for PBXNativeTarget "HiddenTests" */;
+			buildPhases = (
+				637C6E21964C904F331A1E4E /* Sources */,
+				0A920B36E60886C7F0761422 /* Frameworks */,
+				454F8F758E7459D3B795E5E0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C3B52A428D5EEE19E486F2CE /* PBXTargetDependency */,
+			);
+			name = HiddenTests;
+			productName = HiddenTests;
+			productReference = 9C7BF2ECD52E3E5C0D8D7556 /* HiddenTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -290,11 +351,19 @@
 			projectRoot = "";
 			targets = (
 				929113F021F9D04100173149 /* Hidden Bar */,
+				B6ED1C7FB7AE7D98FD4143B2 /* HiddenTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		454F8F758E7459D3B795E5E0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		929113EF21F9D04100173149 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -308,6 +377,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		637C6E21964C904F331A1E4E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A6C9D316FF97AF473765572 /* NotchGeometryTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		929113ED21F9D04100173149 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -337,6 +414,15 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C3B52A428D5EEE19E486F2CE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Hidden Bar";
+			target = 929113F021F9D04100173149 /* Hidden Bar */;
+			targetProxy = 1CD893E4132E5B9D9BBD5DFD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		929113FA21F9D04200173149 /* Main.storyboard */ = {
@@ -374,6 +460,22 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		088F2BBA8058B47FD0E9F5AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarvesv.minimalbar.HiddenTests;
+				PRODUCT_MODULE_NAME = HiddenTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Hidden Bar.app/Contents/MacOS/Hidden Bar";
+			};
+			name = Release;
+		};
 		9291141521F9D04200173149 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -541,9 +643,34 @@
 			};
 			name = Release;
 		};
+		E7F37958ECAEC54771F027C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dwarvesv.minimalbar.HiddenTests;
+				PRODUCT_MODULE_NAME = HiddenTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Hidden Bar.app/Contents/MacOS/Hidden Bar";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		655BFC0A8D76007E8D584889 /* Build configuration list for PBXNativeTarget "HiddenTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				088F2BBA8058B47FD0E9F5AD /* Release */,
+				E7F37958ECAEC54771F027C1 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		929113EC21F9D04100173149 /* Build configuration list for PBXProject "Hidden Bar" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Hidden Bar.xcodeproj/xcshareddata/xcschemes/Hidden Bar.xcscheme
+++ b/Hidden Bar.xcodeproj/xcshareddata/xcschemes/Hidden Bar.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Hidden Bar.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B6ED1C7FB7AE7D98FD4143B2"
+               BuildableName = "HiddenTests.xctest"
+               BlueprintName = "HiddenTests"
+               ReferencedContainer = "container:Hidden Bar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B6ED1C7FB7AE7D98FD4143B2"
+               BuildableName = "HiddenTests.xctest"
+               BlueprintName = "HiddenTests"
+               ReferencedContainer = "container:Hidden Bar.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/HiddenTests/MenuBarExtraClassifierTests.swift
+++ b/HiddenTests/MenuBarExtraClassifierTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Hidden_Bar
+
+private func makeExtra(appName: String, x: CGFloat, width: CGFloat = 22, height: CGFloat = 22, title: String? = nil) -> MenuBarExtraInfo {
+    MenuBarExtraInfo(
+        element: AXUIElementCreateApplication(0),
+        appName: appName,
+        appIcon: nil,
+        title: title,
+        pid: 0,
+        position: CGPoint(x: x, y: 0),
+        size: CGSize(width: width, height: height)
+    )
+}
+
+/// Contract: MenuBarExtraClassifier.classify sorts already-fetched menu-bar
+/// extras into hidden-behind-notch vs visible buckets against a boundary,
+/// independent of how those extras were fetched (the live AXUIElement
+/// enumeration is a separate, non-unit-testable concern).
+/// Serves: NotchOverflowController's overflow menu, which needs a correctly
+/// ordered, correctly bucketed list to render.
+/// Behaviors covered (4): left-of-boundary classifies hidden, at/right-of
+/// boundary classifies visible, zero-size extras are excluded from both
+/// buckets, and each bucket is ordered closest-to-boundary first.
+/// Mock boundary: none — pure function over an array of value-type structs.
+final class MenuBarExtraClassifierTests: XCTestCase {
+
+    // Given an extra positioned left of the boundary
+    // When classifying
+    // Then it lands in the hidden bucket
+    func test_extraLeftOfBoundary_isClassifiedHidden() {
+        let extra = makeExtra(appName: "LeftApp", x: 100)
+
+        let result = MenuBarExtraClassifier.classify([extra], boundary: 500)
+
+        XCTAssertEqual(result.hidden.map(\.appName), ["LeftApp"], "an extra left of the boundary must be hidden")
+        XCTAssertTrue(result.visible.isEmpty, "an extra left of the boundary must not also appear as visible")
+    }
+
+    // Given an extra positioned at or right of the boundary
+    // When classifying
+    // Then it lands in the visible bucket
+    func test_extraAtOrRightOfBoundary_isClassifiedVisible() {
+        let atBoundary = makeExtra(appName: "AtBoundary", x: 500)
+        let rightOfBoundary = makeExtra(appName: "RightApp", x: 900)
+
+        let result = MenuBarExtraClassifier.classify([atBoundary, rightOfBoundary], boundary: 500)
+
+        XCTAssertEqual(Set(result.visible.map(\.appName)), ["AtBoundary", "RightApp"],
+                       "extras at or right of the boundary must be visible")
+        XCTAssertTrue(result.hidden.isEmpty)
+    }
+
+    // Given an extra with zero width or height (a non-rendering placeholder item)
+    // When classifying
+    // Then it is excluded from both buckets
+    func test_zeroSizeExtra_isExcludedFromBothBuckets() {
+        let zeroWidth = makeExtra(appName: "ZeroWidth", x: 100, width: 0)
+        let zeroHeight = makeExtra(appName: "ZeroHeight", x: 900, height: 0)
+
+        let result = MenuBarExtraClassifier.classify([zeroWidth, zeroHeight], boundary: 500)
+
+        XCTAssertTrue(result.hidden.isEmpty, "a zero-width extra is not a real rendered icon")
+        XCTAssertTrue(result.visible.isEmpty, "a zero-height extra is not a real rendered icon")
+    }
+
+    // Given multiple extras in each bucket
+    // When classifying
+    // Then each bucket is ordered closest-to-boundary first (descending X)
+    func test_multipleExtrasPerBucket_areOrderedClosestToBoundaryFirst() {
+        let far = makeExtra(appName: "Far", x: 50)
+        let near = makeExtra(appName: "Near", x: 450)
+
+        let result = MenuBarExtraClassifier.classify([far, near], boundary: 500)
+
+        XCTAssertEqual(result.hidden.map(\.appName), ["Near", "Far"],
+                       "hidden extras must be ordered with the one closest to the notch boundary first")
+    }
+}

--- a/HiddenTests/NotchGeometryTests.swift
+++ b/HiddenTests/NotchGeometryTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Hidden_Bar
+
+final class PlaceholderTests: XCTestCase {
+    func test_testTargetIsWired() {
+        // Given the test target links against the app target
+        // When a trivial assertion runs
+        // Then it passes, proving the test host / bundle loader wiring works
+        XCTAssertTrue(true, "test target should build and run against the app host")
+    }
+}

--- a/HiddenTests/NotchGeometryTests.swift
+++ b/HiddenTests/NotchGeometryTests.swift
@@ -1,11 +1,80 @@
 import XCTest
 @testable import Hidden_Bar
 
-final class PlaceholderTests: XCTestCase {
-    func test_testTargetIsWired() {
-        // Given the test target links against the app target
-        // When a trivial assertion runs
-        // Then it passes, proving the test host / bundle loader wiring works
-        XCTAssertTrue(true, "test target should build and run against the app host")
+/// Contract: NotchGeometry.computeBoundary must tell the notch-overflow
+/// feature (#350) where the notch actually is, replacing the reviewer-flagged
+/// `screen.frame.width / 8` heuristic that produced the wrong boundary on
+/// screens narrower or wider than the size it was tuned against.
+/// Serves: NotchOverflowController, which uses the boundary to classify
+/// menu-bar extras as hidden-behind-notch vs visible.
+/// Behaviors covered (4): no-notch detection, notch detection via
+/// safeAreaInsets, boundary sourced from auxiliaryTopRightArea when present,
+/// and the fallback boundary when a notch is reported but the aux rect is
+/// unavailable (older OS on notch-capable hardware).
+/// Mock boundary: none — this is a pure function over caller-supplied screen
+/// geometry values, no NSScreen/AppKit call inside the function under test.
+final class NotchGeometryTests: XCTestCase {
+
+    // Given a screen reporting no safe-area inset at the top
+    // When computing the notch boundary
+    // Then hasNotch is false
+    func test_screenWithoutSafeAreaInset_reportsNoNotch() {
+        let boundary = NotchGeometry.computeBoundary(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            safeAreaInsetsTop: 0,
+            auxiliaryTopRightAreaMinX: nil
+        )
+
+        XCTAssertFalse(boundary.hasNotch, "a zero top safe-area inset means the screen has no notch")
+    }
+
+    // Given a screen reporting a positive top safe-area inset
+    // When computing the notch boundary
+    // Then hasNotch is true
+    func test_screenWithSafeAreaInset_reportsNotch() {
+        let boundary = NotchGeometry.computeBoundary(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            safeAreaInsetsTop: 32,
+            auxiliaryTopRightAreaMinX: 810
+        )
+
+        XCTAssertTrue(boundary.hasNotch, "a positive top safe-area inset means the screen has a notch")
+    }
+
+    // Given a notch screen with a known auxiliaryTopRightArea boundary
+    // When computing the notch boundary
+    // Then the threshold is exactly that boundary, not a fraction of screen width
+    func test_notchScreen_usesAuxiliaryTopRightAreaAsThreshold_notWidthFraction() {
+        // Two different screen widths sharing a real reported aux-area boundary
+        // regression-guards the exact bug flagged in review: the old
+        // `screen.frame.width / 8`-derived value would differ between these,
+        // even though the real hardware boundary here does not.
+        let narrowerScreen = NotchGeometry.computeBoundary(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            safeAreaInsetsTop: 32,
+            auxiliaryTopRightAreaMinX: 810
+        )
+        let widerScreen = NotchGeometry.computeBoundary(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            safeAreaInsetsTop: 32,
+            auxiliaryTopRightAreaMinX: 810
+        )
+
+        XCTAssertEqual(narrowerScreen.overflowThresholdX, 810, "threshold must come straight from the reported aux-area rect")
+        XCTAssertEqual(widerScreen.overflowThresholdX, 810, "threshold must not scale with screen width when the real boundary doesn't")
+    }
+
+    // Given a notch is reported but no auxiliaryTopRightArea is available
+    // When computing the notch boundary
+    // Then it falls back to the documented default rather than 0 or a crash
+    func test_notchWithoutAuxiliaryArea_fallsBackToDefaultThreshold() {
+        let boundary = NotchGeometry.computeBoundary(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            safeAreaInsetsTop: 32,
+            auxiliaryTopRightAreaMinX: nil
+        )
+
+        XCTAssertEqual(boundary.overflowThresholdX, NotchGeometry.fallbackThresholdX,
+                       "missing aux-area data on a reported notch must degrade to the documented fallback")
     }
 }

--- a/HiddenTests/NotchOverflowMenuBuilderTests.swift
+++ b/HiddenTests/NotchOverflowMenuBuilderTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Hidden_Bar
+
+private func makeExtra(appName: String, x: CGFloat, title: String? = nil) -> MenuBarExtraInfo {
+    MenuBarExtraInfo(
+        element: AXUIElementCreateApplication(0),
+        appName: appName,
+        appIcon: nil,
+        title: title,
+        pid: 0,
+        position: CGPoint(x: x, y: 0),
+        size: CGSize(width: 22, height: 22)
+    )
+}
+
+/// Contract: NotchOverflowController.buildOverflowMenu must render a
+/// correct, inspectable NSMenu from already-classified extras. NSMenu/
+/// NSMenuItem construction runs headlessly (no window needed), so this is
+/// unit-testable despite living in an AppKit-heavy controller.
+/// Serves: the user browsing the overflow menu to find and reach an icon
+/// that macOS silently dropped behind the notch.
+/// Behaviors covered (4): empty state when nothing is found, section headers
+/// carry correct counts, an extra with an empty title falls back to the app
+/// name, and a hidden extra's title is visually distinguished (tinted) from
+/// a visible one.
+/// Mock boundary: extras and boundary are injected directly, bypassing the
+/// live AXUIElement enumeration (getAllMenuBarExtras), which is not
+/// unit-testable without a real Accessibility-permitted process.
+final class NotchOverflowMenuBuilderTests: XCTestCase {
+
+    private var controller: NotchOverflowController!
+
+    override func setUp() {
+        super.setUp()
+        controller = NotchOverflowController()
+    }
+
+    // Given no extras were found
+    // When building the overflow menu
+    // Then it shows a single disabled empty-state item
+    func test_noExtrasFound_showsDisabledEmptyStateItem() {
+        let menu = controller.buildOverflowMenu(extras: [], boundary: 500)
+
+        let emptyStateItem = menu.items.first { $0.title.contains("No items found") }
+        XCTAssertNotNil(emptyStateItem, "an empty result must surface a message explaining why, not a blank menu")
+        XCTAssertEqual(emptyStateItem?.isEnabled, false, "the empty-state message is informational, not actionable")
+    }
+
+    // Given a mix of hidden and visible extras
+    // When building the overflow menu
+    // Then the section headers report the correct counts
+    func test_mixOfHiddenAndVisibleExtras_headersShowCorrectCounts() {
+        let extras = [
+            makeExtra(appName: "Hidden1", x: 100),
+            makeExtra(appName: "Hidden2", x: 150),
+            makeExtra(appName: "Visible1", x: 900),
+        ]
+
+        let menu = controller.buildOverflowMenu(extras: extras, boundary: 500)
+
+        let hiddenHeader = menu.items.first { $0.title.contains("Hidden Behind Notch") }
+        let visibleHeader = menu.items.first { $0.title.contains("Visible") && !$0.title.contains("Hidden") }
+        XCTAssertEqual(hiddenHeader?.title.contains("2"), true, "two hidden extras must be reflected in the header count")
+        XCTAssertEqual(visibleHeader?.title.contains("1"), true, "one visible extra must be reflected in the header count")
+    }
+
+    // Given an extra with an empty AX title
+    // When building its menu item
+    // Then the item falls back to the app's name
+    func test_extraWithEmptyTitle_fallsBackToAppName() {
+        let extras = [makeExtra(appName: "FallbackApp", x: 900, title: "")]
+
+        let menu = controller.buildOverflowMenu(extras: extras, boundary: 500)
+
+        let item = menu.items.first { $0.representedObject is MenuBarExtraInfo }
+        XCTAssertEqual(item?.title, "FallbackApp", "an empty AX title must fall back to the owning app's name")
+    }
+
+    // Given a hidden extra
+    // When building its menu item
+    // Then its title is tinted orange to distinguish it from a visible one
+    func test_hiddenExtra_hasTintedAttributedTitle() {
+        let extras = [makeExtra(appName: "HiddenApp", x: 100)]
+
+        let menu = controller.buildOverflowMenu(extras: extras, boundary: 500)
+
+        let item = menu.items.first { $0.representedObject is MenuBarExtraInfo }
+        let color = item?.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertEqual(color, NSColor.systemOrange, "a hidden extra's title must be tinted to distinguish it visually from a visible one")
+    }
+}

--- a/HiddenTests/NotchOverflowMenuBuilderTests.swift
+++ b/HiddenTests/NotchOverflowMenuBuilderTests.swift
@@ -19,10 +19,11 @@ private func makeExtra(appName: String, x: CGFloat, title: String? = nil) -> Men
 /// unit-testable despite living in an AppKit-heavy controller.
 /// Serves: the user browsing the overflow menu to find and reach an icon
 /// that macOS silently dropped behind the notch.
-/// Behaviors covered (4): empty state when nothing is found, section headers
-/// carry correct counts, an extra with an empty title falls back to the app
-/// name, and a hidden extra's title is visually distinguished (tinted) from
-/// a visible one.
+/// Behaviors covered (5): empty state when nothing is found, section headers
+/// carry correct counts, section headers render at full-contrast label color
+/// (not the dim secondary/default-disabled style), an extra with an empty
+/// title falls back to the app name, and a hidden extra's title is visually
+/// distinguished by glyph and weight from a visible one.
 /// Mock boundary: extras and boundary are injected directly, bypassing the
 /// live AXUIElement enumeration (getAllMenuBarExtras), which is not
 /// unit-testable without a real Accessibility-permitted process.
@@ -64,6 +65,21 @@ final class NotchOverflowMenuBuilderTests: XCTestCase {
         XCTAssertEqual(visibleHeader?.title.contains("1"), true, "one visible extra must be reflected in the header count")
     }
 
+    // Given a section header (the top title, or a hidden/visible count header)
+    // When it's rendered
+    // Then it uses full-contrast labelColor, not secondaryLabelColor or
+    // AppKit's default dimmed disabled-item style, since the dim style read
+    // poorly against a dark selection highlight
+    func test_sectionHeaders_useFullContrastLabelColor_notDimmed() {
+        let extras = [makeExtra(appName: "HiddenApp", x: 100)]
+
+        let menu = controller.buildOverflowMenu(extras: extras, boundary: 500)
+
+        let header = menu.items.first { $0.title.contains("Hidden Behind Notch") }
+        let color = header?.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        XCTAssertEqual(color, NSColor.labelColor, "a section header must use the normal full-contrast label color")
+    }
+
     // Given an extra with an empty AX title
     // When building its menu item
     // Then the item falls back to the app's name
@@ -78,14 +94,20 @@ final class NotchOverflowMenuBuilderTests: XCTestCase {
 
     // Given a hidden extra
     // When building its menu item
-    // Then its title is tinted orange to distinguish it from a visible one
-    func test_hiddenExtra_hasTintedAttributedTitle() {
+    // Then it's distinguished by a warning glyph and bold weight, not color
+    // alone (color-only signaling gives colorblind users nothing, and reads
+    // poorly against a dark selection highlight)
+    func test_hiddenExtra_isDistinguishedByGlyphAndWeight_notColorAlone() {
         let extras = [makeExtra(appName: "HiddenApp", x: 100)]
 
         let menu = controller.buildOverflowMenu(extras: extras, boundary: 500)
 
         let item = menu.items.first { $0.representedObject is MenuBarExtraInfo }
+        XCTAssertEqual(item?.attributedTitle?.string, "\u{26A0}\u{FE0F} HiddenApp",
+                       "a hidden extra's title must be prefixed with a warning glyph")
+        let font = item?.attributedTitle?.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        XCTAssertEqual(font, NSFont.boldSystemFont(ofSize: 13), "a hidden extra's title must be bold")
         let color = item?.attributedTitle?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
-        XCTAssertEqual(color, NSColor.systemOrange, "a hidden extra's title must be tinted to distinguish it visually from a visible one")
+        XCTAssertEqual(color, NSColor.labelColor, "a hidden extra's title must stay at the normal legible label color")
     }
 }

--- a/HiddenTests/NotchOverflowPreferencesTests.swift
+++ b/HiddenTests/NotchOverflowPreferencesTests.swift
@@ -7,16 +7,16 @@ import XCTest
 /// flagged ("should we have a way to enable/disable this feature
 /// manually?") that the original PR never actually wired into any UI.
 /// Serves: the Preferences checkbox (PreferencesViewController) and
-/// StatusBarController's context-menu rebuild, both of which depend on this
-/// preference's get/set/notify contract.
-/// Behaviors covered (3): fresh-install default is `true`, setting the
-/// preference persists the new value, and setting it posts the
-/// `.notchOverflowToggle` notification StatusBarController listens for.
-/// Mock boundary: none — exercises the real `UserDefaults.standard` and
-/// `NotificationCenter.default`, saving/restoring prior state around each
-/// test since this preference is process-wide shared state, matching how
-/// the rest of this codebase's Preferences enum already works (no DI seam
-/// exists there to mock against).
+/// StatusBarController's context menu, which reads this preference fresh
+/// every time getContextMenu() builds a new menu for the next presentation
+/// (see showContextMenu(from:)) rather than needing a push notification to
+/// stay in sync.
+/// Behaviors covered (2): fresh-install default is `true`, and setting the
+/// preference persists the new value.
+/// Mock boundary: none — exercises the real `UserDefaults.standard`, saving/
+/// restoring prior state around each test since this preference is
+/// process-wide shared state, matching how the rest of this codebase's
+/// Preferences enum already works (no DI seam exists there to mock against).
 final class NotchOverflowPreferencesTests: XCTestCase {
 
     private var priorValue: Bool!
@@ -48,16 +48,5 @@ final class NotchOverflowPreferencesTests: XCTestCase {
         Preferences.notchOverflowEnabled = false
 
         XCTAssertFalse(Preferences.notchOverflowEnabled, "the preference must persist the value it was set to")
-    }
-
-    // Given an observer registered for the toggle notification
-    // When the preference is set
-    // Then the .notchOverflowToggle notification fires
-    func test_settingPreference_postsNotchOverflowToggleNotification() {
-        let expectation = expectation(forNotification: .notchOverflowToggle, object: nil)
-
-        Preferences.notchOverflowEnabled = !priorValue
-
-        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/HiddenTests/NotchOverflowPreferencesTests.swift
+++ b/HiddenTests/NotchOverflowPreferencesTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Hidden_Bar
+
+/// Contract: Preferences.notchOverflowEnabled and AppDelegate's default
+/// values must give the user an explicit, persistent, discoverable way to
+/// turn the notch-overflow feature off — the exact gap the reviewer on #350
+/// flagged ("should we have a way to enable/disable this feature
+/// manually?") that the original PR never actually wired into any UI.
+/// Serves: the Preferences checkbox (PreferencesViewController) and
+/// StatusBarController's context-menu rebuild, both of which depend on this
+/// preference's get/set/notify contract.
+/// Behaviors covered (3): fresh-install default is `true`, setting the
+/// preference persists the new value, and setting it posts the
+/// `.notchOverflowToggle` notification StatusBarController listens for.
+/// Mock boundary: none — exercises the real `UserDefaults.standard` and
+/// `NotificationCenter.default`, saving/restoring prior state around each
+/// test since this preference is process-wide shared state, matching how
+/// the rest of this codebase's Preferences enum already works (no DI seam
+/// exists there to mock against).
+final class NotchOverflowPreferencesTests: XCTestCase {
+
+    private var priorValue: Bool!
+
+    override func setUp() {
+        super.setUp()
+        priorValue = UserDefaults.standard.bool(forKey: UserDefaults.Key.notchOverflowEnabled)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.set(priorValue, forKey: UserDefaults.Key.notchOverflowEnabled)
+        super.tearDown()
+    }
+
+    // Given a fresh install (defaults never registered by the user)
+    // When reading the app's declared default preference values
+    // Then notchOverflowEnabled defaults to true
+    func test_defaultPreferenceValues_notchOverflowEnabledDefaultsToTrue() {
+        let defaults = AppDelegate.defaultPreferenceValues
+
+        XCTAssertEqual(defaults[UserDefaults.Key.notchOverflowEnabled] as? Bool, true,
+                       "a first-time user should see notch overflow available without opting in")
+    }
+
+    // Given the preference is set to false
+    // When reading it back
+    // Then it reports false (the setter/getter round-trip persists correctly)
+    func test_settingPreferenceFalse_persistsAndReadsBackFalse() {
+        Preferences.notchOverflowEnabled = false
+
+        XCTAssertFalse(Preferences.notchOverflowEnabled, "the preference must persist the value it was set to")
+    }
+
+    // Given an observer registered for the toggle notification
+    // When the preference is set
+    // Then the .notchOverflowToggle notification fires
+    func test_settingPreference_postsNotchOverflowToggleNotification() {
+        let expectation = expectation(forNotification: .notchOverflowToggle, object: nil)
+
+        Preferences.notchOverflowEnabled = !priorValue
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import AppKit
+import Carbon
 import HotKey
 import ServiceManagement
 
@@ -15,16 +16,19 @@ import ServiceManagement
 class AppDelegate: NSObject, NSApplicationDelegate{
     
     var statusBarController = StatusBarController()
-    
+
     var hotKey: HotKey? {
         didSet {
             guard let hotKey = hotKey else { return }
-            
+
             hotKey.keyDownHandler = { [weak self] in
                 self?.statusBarController.expandCollapseIfNeeded()
             }
         }
     }
+
+    // Notch overflow hotkey: Cmd+Shift+B
+    var notchOverflowHotKey: HotKey?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         setupAutoStartApp()
@@ -32,6 +36,18 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         setupHotKey()
         openPreferencesIfNeeded()
         detectLTRLang()
+        statusBarController.setupNotchOverflow()
+        setupNotchOverflowHotKey()
+    }
+
+    func setupNotchOverflowHotKey() {
+        guard NotchOverflowController.hasNotch else { return }
+        // Cmd+Shift+B (keyCode 11 = B)
+        let carbonMods = UInt32(cmdKey | shiftKey)
+        notchOverflowHotKey = HotKey(keyCombo: KeyCombo(carbonKeyCode: 11, carbonModifiers: carbonMods))
+        notchOverflowHotKey?.keyDownHandler = { [weak self] in
+            self?.statusBarController.notchOverflowController.triggerOverflow()
+        }
     }
     
     func openPreferencesIfNeeded() {
@@ -61,7 +77,8 @@ class AppDelegate: NSObject, NSApplicationDelegate{
             UserDefaults.Key.isAutoHide: true,
             UserDefaults.Key.numberOfSecondForAutoHide: 10.0,
             UserDefaults.Key.areSeparatorsHidden: false,
-            UserDefaults.Key.alwaysHiddenSectionEnabled: false
+            UserDefaults.Key.alwaysHiddenSectionEnabled: false,
+            UserDefaults.Key.notchOverflowEnabled: true
          ])
     }
     

--- a/hidden/AppDelegate.swift
+++ b/hidden/AppDelegate.swift
@@ -7,7 +7,6 @@
 //
 
 import AppKit
-import Carbon
 import HotKey
 import ServiceManagement
 
@@ -27,29 +26,15 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         }
     }
 
-    // Notch overflow hotkey: Cmd+Shift+B
-    var notchOverflowHotKey: HotKey?
-
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         setupAutoStartApp()
         registerDefaultValues()
         setupHotKey()
         openPreferencesIfNeeded()
         detectLTRLang()
-        statusBarController.setupNotchOverflow()
-        setupNotchOverflowHotKey()
     }
 
-    func setupNotchOverflowHotKey() {
-        guard NotchOverflowController.hasNotch else { return }
-        // Cmd+Shift+B (keyCode 11 = B)
-        let carbonMods = UInt32(cmdKey | shiftKey)
-        notchOverflowHotKey = HotKey(keyCombo: KeyCombo(carbonKeyCode: 11, carbonModifiers: carbonMods))
-        notchOverflowHotKey?.keyDownHandler = { [weak self] in
-            self?.statusBarController.notchOverflowController.triggerOverflow()
-        }
-    }
-    
+
     func openPreferencesIfNeeded() {
         if Preferences.isShowPreference {
             Util.showPrefWindow()
@@ -70,16 +55,21 @@ class AppDelegate: NSObject, NSApplicationDelegate{
         UserDefaults.standard.set(true, forKey: migratedKey)
     }
     
+    // A plain value, separate from the side-effecting `register(defaults:)`
+    // call, so the "what are the defaults" behavior is testable without
+    // spinning up an AppDelegate (which creates real status bar items).
+    static let defaultPreferenceValues: [String: Any] = [
+        UserDefaults.Key.isAutoStart: false,
+        UserDefaults.Key.isShowPreference: true,
+        UserDefaults.Key.isAutoHide: true,
+        UserDefaults.Key.numberOfSecondForAutoHide: 10.0,
+        UserDefaults.Key.areSeparatorsHidden: false,
+        UserDefaults.Key.alwaysHiddenSectionEnabled: false,
+        UserDefaults.Key.notchOverflowEnabled: true
+    ]
+
     func registerDefaultValues() {
-         UserDefaults.standard.register(defaults: [
-            UserDefaults.Key.isAutoStart: false,
-            UserDefaults.Key.isShowPreference: true,
-            UserDefaults.Key.isAutoHide: true,
-            UserDefaults.Key.numberOfSecondForAutoHide: 10.0,
-            UserDefaults.Key.areSeparatorsHidden: false,
-            UserDefaults.Key.alwaysHiddenSectionEnabled: false,
-            UserDefaults.Key.notchOverflowEnabled: true
-         ])
+        UserDefaults.standard.register(defaults: AppDelegate.defaultPreferenceValues)
     }
     
     func setupHotKey() {

--- a/hidden/Base.lproj/Main.storyboard
+++ b/hidden/Base.lproj/Main.storyboard
@@ -755,6 +755,16 @@ between sections to configure Hidden Bar.</string>
                                                     <real value="3.4028234663852886e+38"/>
                                                 </customSpacing>
                                             </stackView>
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ntc-Ov-Bx1" userLabel="Check Box Notch Overflow">
+                                                <rect key="frame" x="-2" y="-25" width="320" height="18"/>
+                                                <buttonCell key="cell" type="check" title="Enable Notch Overflow (right-click &#8249; to access hidden icons)" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Ntc-Ov-Cl1">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="notchOverflowCheckChanged:" target="XfG-lQ-9wD" id="Ntc-Ov-Ac1"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <visibilityPriorities>
                                             <integer value="1000"/>
@@ -762,8 +772,10 @@ between sections to configure Hidden Bar.</string>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
                                             <integer value="1000"/>
+                                            <integer value="1000"/>
                                         </visibilityPriorities>
                                         <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
                                             <real value="3.4028234663852886e+38"/>
@@ -862,6 +874,7 @@ between sections to configure Hidden Bar.</string>
                         <outlet property="btnShortcut" destination="yKf-P1-I45" id="AFr-y7-VbP"/>
                         <outlet property="checkBoxAutoHide" destination="gj1-Ms-4No" id="Ibl-5H-2vh"/>
                         <outlet property="checkBoxLogin" destination="cbR-Jv-adm" id="DFO-De-0KU"/>
+                        <outlet property="checkBoxNotchOverflow" destination="Ntc-Ov-Bx1" id="Ntc-Ov-Ot1"/>
                         <outlet property="checkBoxShowAlwaysHiddenSection" destination="yaS-iD-h7g" id="T5N-bN-yl2"/>
                         <outlet property="checkBoxShowPreferences" destination="gWT-L1-Xdf" id="sC8-cw-Fmh"/>
                         <outlet property="checkBoxUseFullStatusbar" destination="EQP-7r-FSu" id="Vll-3t-F9V"/>

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -109,11 +109,20 @@ enum Preferences {
         get {
             UserDefaults.standard.bool(forKey: UserDefaults.Key.useFullStatusBarOnExpandEnabled)
         }
-        
+
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.useFullStatusBarOnExpandEnabled)
         }
     }
-    
-    
+
+    static var notchOverflowEnabled: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaults.Key.notchOverflowEnabled)
+        }
+
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.notchOverflowEnabled)
+            NotificationCenter.default.post(Notification(name: .notchOverflowToggle))
+        }
+    }
 }

--- a/hidden/Common/Preferences.swift
+++ b/hidden/Common/Preferences.swift
@@ -122,7 +122,6 @@ enum Preferences {
 
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaults.Key.notchOverflowEnabled)
-            NotificationCenter.default.post(Notification(name: .notchOverflowToggle))
         }
     }
 }

--- a/hidden/Extensions/Notification.Name+Extension.swift
+++ b/hidden/Extensions/Notification.Name+Extension.swift
@@ -12,4 +12,5 @@ extension Notification.Name {
     
     static let prefsChanged = Notification.Name("prefsChanged")
     static let alwayHideToggle = Notification.Name("alwayHideToggle")
+    static let notchOverflowToggle = Notification.Name("notchOverflowToggle")
 }

--- a/hidden/Extensions/Notification.Name+Extension.swift
+++ b/hidden/Extensions/Notification.Name+Extension.swift
@@ -12,5 +12,4 @@ extension Notification.Name {
     
     static let prefsChanged = Notification.Name("prefsChanged")
     static let alwayHideToggle = Notification.Name("alwayHideToggle")
-    static let notchOverflowToggle = Notification.Name("notchOverflowToggle")
 }

--- a/hidden/Extensions/UserDefault+Extension.swift
+++ b/hidden/Extensions/UserDefault+Extension.swift
@@ -19,5 +19,10 @@ extension UserDefaults {
         static let alwaysHiddenSectionEnabled = "alwaysHiddenSectionEnabled"
         static let useFullStatusBarOnExpandEnabled = "useFullStatusBarOnExpandEnabled"
         static let hoverToExpand = "hoverToExpand"
+        static let notchOverflowEnabled = "notchOverflowEnabled"
+    }
+
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        print("hi!")
     }
 }

--- a/hidden/Features/NotchOverflow/NotchOverflowController.swift
+++ b/hidden/Features/NotchOverflow/NotchOverflowController.swift
@@ -1,0 +1,279 @@
+//
+//  NotchOverflowController.swift
+//  Hidden Bar
+//
+//  Created by Nadir on 2026/03/30.
+//  Copyright © 2026 Dwarves Foundation. All rights reserved.
+//
+
+import AppKit
+import ApplicationServices
+
+// MARK: - Menu Bar Extra Info
+
+struct MenuBarExtraInfo {
+  let element: AXUIElement
+  let appName: String
+  let appIcon: NSImage?
+  let title: String?
+  let pid: pid_t
+  let position: CGPoint
+  let size: CGSize
+}
+
+// MARK: - NotchOverflowController
+
+class NotchOverflowController: NSObject {
+
+  // MARK: - Properties
+
+  /// Right edge of the notch in screen X coordinates
+  private var notchRightEdge: CGFloat {
+    guard let screen = NSScreen.main else { return 972 }
+    let notchWidth = screen.frame.width / 8
+    return screen.frame.width / 2 + notchWidth / 2
+  }
+
+  // MARK: - Notch Detection
+
+  static var hasNotch: Bool {
+    if #available(macOS 12.0, *) {
+      guard let screen = NSScreen.main else { return false }
+      return screen.safeAreaInsets.top > 0
+    }
+    return false
+  }
+
+  // MARK: - Setup
+
+  func setup() {
+    // No-op; hotkey is set up in AppDelegate
+  }
+
+  func teardown() {
+    // No-op
+  }
+
+  // MARK: - Public: called from hotkey handler
+  func triggerOverflow() {
+    showOverflowMenuAtCursor()
+  }
+
+  /// Show overflow menu anchored to a status item (called from StatusBarController)
+  func showOverflowMenuFromSeparator(near item: NSStatusItem) {
+    guard ensureAccessibility() else { return }
+    let menu = buildOverflowMenu()
+    item.menu = menu
+    item.button?.performClick(nil)
+    DispatchQueue.main.async {
+      item.menu = nil
+    }
+  }
+
+  // MARK: - Show Menu at Cursor
+
+  private func showOverflowMenuAtCursor() {
+    guard ensureAccessibility() else { return }
+
+    let menu = buildOverflowMenu()
+    let mouseLocation = NSEvent.mouseLocation
+
+    // Create a temporary invisible window at mouse location to anchor the menu
+    let tmpWindow = NSWindow(
+      contentRect: NSRect(x: mouseLocation.x - 1, y: mouseLocation.y - 1, width: 2, height: 2),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    tmpWindow.level = .popUpMenu
+    tmpWindow.backgroundColor = .clear
+    tmpWindow.isOpaque = false
+    tmpWindow.orderFrontRegardless()
+
+    menu.popUp(positioning: nil, at: NSPoint(x: 1, y: 1), in: tmpWindow.contentView)
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      tmpWindow.orderOut(nil)
+    }
+  }
+
+  // MARK: - Menu Building
+
+  private func buildOverflowMenu() -> NSMenu {
+    let allExtras = getAllMenuBarExtras()
+
+    let rightEdge = notchRightEdge
+    let hiddenExtras = allExtras.filter {
+      $0.size.width > 0 && $0.size.height > 0 && $0.position.x < rightEdge
+    }
+    let visibleExtras = allExtras.filter {
+      $0.size.width > 0 && $0.size.height > 0 && $0.position.x >= rightEdge
+    }
+
+    let menu = NSMenu()
+    menu.autoenablesItems = false
+
+    // Title
+    let titleItem = NSMenuItem(title: "Notch Overflow  \u{2318}\u{21E7}B", action: nil, keyEquivalent: "")
+    titleItem.isEnabled = false
+    if #available(macOS 10.14, *) {
+      titleItem.attributedTitle = NSAttributedString(
+        string: titleItem.title,
+        attributes: [
+          .font: NSFont.systemFont(ofSize: 12, weight: .bold),
+          .foregroundColor: NSColor.secondaryLabelColor
+        ])
+    }
+    menu.addItem(titleItem)
+    menu.addItem(NSMenuItem.separator())
+
+    // Hidden section
+    if !hiddenExtras.isEmpty {
+      let header = NSMenuItem(
+        title: "\u{26A0} Hidden Behind Notch (\(hiddenExtras.count))",
+        action: nil, keyEquivalent: "")
+      header.isEnabled = false
+      menu.addItem(header)
+      menu.addItem(NSMenuItem.separator())
+
+      for info in hiddenExtras.sorted(by: { $0.position.x > $1.position.x }) {
+        menu.addItem(makeMenuItem(for: info, hidden: true))
+      }
+    }
+
+    // Visible section
+    if !visibleExtras.isEmpty {
+      if !hiddenExtras.isEmpty { menu.addItem(NSMenuItem.separator()) }
+      let header = NSMenuItem(
+        title: "Visible (\(visibleExtras.count))",
+        action: nil, keyEquivalent: "")
+      header.isEnabled = false
+      menu.addItem(header)
+      menu.addItem(NSMenuItem.separator())
+
+      for info in visibleExtras.sorted(by: { $0.position.x > $1.position.x }) {
+        menu.addItem(makeMenuItem(for: info, hidden: false))
+      }
+    }
+
+    // Empty state
+    if hiddenExtras.isEmpty && visibleExtras.isEmpty {
+      let emptyItem = NSMenuItem(
+        title: "No items found (grant Accessibility permission)",
+        action: nil, keyEquivalent: "")
+      emptyItem.isEnabled = false
+      menu.addItem(emptyItem)
+    }
+
+    return menu
+  }
+
+  private func makeMenuItem(for info: MenuBarExtraInfo, hidden: Bool = false) -> NSMenuItem {
+    let item = NSMenuItem()
+    let displayTitle = (info.title?.isEmpty == false) ? info.title! : info.appName
+
+    if hidden {
+      if #available(macOS 10.14, *) {
+        item.attributedTitle = NSAttributedString(
+          string: displayTitle,
+          attributes: [
+            .font: NSFont.systemFont(ofSize: 13),
+            .foregroundColor: NSColor.systemOrange
+          ])
+      } else {
+        item.title = displayTitle
+      }
+    } else {
+      item.title = displayTitle
+    }
+
+    if let icon = info.appIcon {
+      item.image = hidden ? icon.resizedForMenu(tinted: true) : icon.resizedForMenu()
+    }
+    item.representedObject = info
+    item.target = self
+    item.action = #selector(activateItem(_:))
+    return item
+  }
+
+  @objc private func activateItem(_ sender: NSMenuItem) {
+    guard let info = sender.representedObject as? MenuBarExtraInfo else { return }
+    AXUIElementPerformAction(info.element, kAXPressAction as CFString)
+  }
+
+  // MARK: - Accessibility
+
+  private func ensureAccessibility() -> Bool {
+    if AXIsProcessTrusted() { return true }
+    let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
+    AXIsProcessTrustedWithOptions(opts)
+    return false
+  }
+
+  // MARK: - AX Enumeration
+
+  private func getAllMenuBarExtras() -> [MenuBarExtraInfo] {
+    var results: [MenuBarExtraInfo] = []
+    let myPID = ProcessInfo.processInfo.processIdentifier
+
+    for app in NSWorkspace.shared.runningApplications {
+      if app.processIdentifier == myPID { continue }
+
+      let axApp = AXUIElementCreateApplication(app.processIdentifier)
+      var extrasRef: AnyObject?
+      let err = AXUIElementCopyAttributeValue(
+        axApp, "AXExtrasMenuBar" as CFString, &extrasRef)
+      guard err == .success else { continue }
+
+      var childrenRef: AnyObject?
+      let childErr = AXUIElementCopyAttributeValue(
+        extrasRef as! AXUIElement,
+        kAXChildrenAttribute as CFString, &childrenRef)
+      guard childErr == .success,
+        let children = childrenRef as? [AXUIElement]
+      else { continue }
+
+      for child in children {
+        var titleRef: AnyObject?
+        AXUIElementCopyAttributeValue(child, kAXTitleAttribute as CFString, &titleRef)
+
+        var posRef: AnyObject?
+        AXUIElementCopyAttributeValue(child, kAXPositionAttribute as CFString, &posRef)
+        var pos = CGPoint.zero
+        if let pv = posRef { AXValueGetValue(pv as! AXValue, .cgPoint, &pos) }
+
+        var sizeRef: AnyObject?
+        AXUIElementCopyAttributeValue(child, kAXSizeAttribute as CFString, &sizeRef)
+        var size = CGSize.zero
+        if let sv = sizeRef { AXValueGetValue(sv as! AXValue, .cgSize, &size) }
+
+        results.append(MenuBarExtraInfo(
+          element: child,
+          appName: app.localizedName ?? "Unknown",
+          appIcon: app.icon,
+          title: titleRef as? String,
+          pid: app.processIdentifier,
+          position: pos,
+          size: size
+        ))
+      }
+    }
+    return results
+  }
+
+}
+
+// MARK: - NSImage Extension
+
+private extension NSImage {
+  func resizedForMenu(tinted: Bool = false) -> NSImage {
+    let target = NSSize(width: 18, height: 18)
+    let img = NSImage(size: target)
+    img.lockFocus()
+    self.draw(in: NSRect(origin: .zero, size: target),
+              from: NSRect(origin: .zero, size: self.size),
+              operation: .sourceOver, fraction: tinted ? 0.5 : 1.0)
+    img.unlockFocus()
+    return img
+  }
+}

--- a/hidden/Features/NotchOverflow/NotchOverflowController.swift
+++ b/hidden/Features/NotchOverflow/NotchOverflowController.swift
@@ -21,42 +21,92 @@ struct MenuBarExtraInfo {
   let size: CGSize
 }
 
+// MARK: - Notch Geometry
+
+/// Pure geometry: where the notch is and which X coordinates on the menu-bar
+/// row it makes unreachable. Kept free of NSScreen/AppKit calls so it can be
+/// unit-tested with synthetic screen values instead of live hardware.
+struct NotchBoundary: Equatable {
+  let hasNotch: Bool
+  /// The leftmost X, in screen coordinates, at which a status item is
+  /// guaranteed clear of the notch. Items positioned left of this are
+  /// either under the notch or squeezed off past its left edge.
+  let overflowThresholdX: CGFloat
+}
+
+enum NotchGeometry {
+  // Matches the pre-fix behavior's default (half of a common 1728pt-wide
+  // screen) so a screen that unexpectedly can't report safeAreaInsets still
+  // gets a sane threshold instead of 0.
+  static let fallbackThresholdX: CGFloat = 972
+
+  /// - Parameters:
+  ///   - screenFrame: the candidate screen's full frame (`NSScreen.frame`).
+  ///   - safeAreaInsetsTop: `NSScreen.safeAreaInsets.top`; > 0 on notched Macs.
+  ///   - auxiliaryTopRightAreaMinX: `NSScreen.auxiliaryTopRightArea?.minX`,
+  ///     Apple's own safe-rect boundary for content right of the notch.
+  static func computeBoundary(
+    screenFrame: CGRect,
+    safeAreaInsetsTop: CGFloat,
+    auxiliaryTopRightAreaMinX: CGFloat?
+  ) -> NotchBoundary {
+    let hasNotch = safeAreaInsetsTop > 0
+    guard hasNotch, let thresholdX = auxiliaryTopRightAreaMinX else {
+      return NotchBoundary(hasNotch: hasNotch, overflowThresholdX: fallbackThresholdX)
+    }
+    return NotchBoundary(hasNotch: true, overflowThresholdX: thresholdX)
+  }
+}
+
+// MARK: - Extras Classification
+
+/// Pure classification of already-fetched extras against a boundary. Split
+/// from AX enumeration so the sorting/filtering rules are testable without
+/// a live Accessibility permission or other running apps.
+enum MenuBarExtraClassifier {
+  static func classify(
+    _ extras: [MenuBarExtraInfo],
+    boundary: CGFloat
+  ) -> (hidden: [MenuBarExtraInfo], visible: [MenuBarExtraInfo]) {
+    let renderable = extras.filter { $0.size.width > 0 && $0.size.height > 0 }
+    let hidden = renderable
+      .filter { $0.position.x < boundary }
+      .sorted { $0.position.x > $1.position.x }
+    let visible = renderable
+      .filter { $0.position.x >= boundary }
+      .sorted { $0.position.x > $1.position.x }
+    return (hidden, visible)
+  }
+}
+
 // MARK: - NotchOverflowController
 
 class NotchOverflowController: NSObject {
 
-  // MARK: - Properties
-
-  /// Right edge of the notch in screen X coordinates
-  private var notchRightEdge: CGFloat {
-    guard let screen = NSScreen.main else { return 972 }
-    let notchWidth = screen.frame.width / 8
-    return screen.frame.width / 2 + notchWidth / 2
-  }
-
   // MARK: - Notch Detection
 
-  static var hasNotch: Bool {
-    if #available(macOS 12.0, *) {
-      guard let screen = NSScreen.main else { return false }
-      return screen.safeAreaInsets.top > 0
+  private static func currentBoundary() -> NotchBoundary {
+    guard let screen = NSScreen.main else {
+      return NotchBoundary(hasNotch: false, overflowThresholdX: NotchGeometry.fallbackThresholdX)
     }
-    return false
+    let safeAreaTop: CGFloat
+    let auxRightMinX: CGFloat?
+    if #available(macOS 12.0, *) {
+      safeAreaTop = screen.safeAreaInsets.top
+      auxRightMinX = screen.auxiliaryTopRightArea?.minX
+    } else {
+      safeAreaTop = 0
+      auxRightMinX = nil
+    }
+    return NotchGeometry.computeBoundary(
+      screenFrame: screen.frame,
+      safeAreaInsetsTop: safeAreaTop,
+      auxiliaryTopRightAreaMinX: auxRightMinX
+    )
   }
 
-  // MARK: - Setup
-
-  func setup() {
-    // No-op; hotkey is set up in AppDelegate
-  }
-
-  func teardown() {
-    // No-op
-  }
-
-  // MARK: - Public: called from hotkey handler
-  func triggerOverflow() {
-    showOverflowMenuAtCursor()
+  static var hasNotch: Bool {
+    currentBoundary().hasNotch
   }
 
   /// Show overflow menu anchored to a status item (called from StatusBarController)
@@ -70,51 +120,21 @@ class NotchOverflowController: NSObject {
     }
   }
 
-  // MARK: - Show Menu at Cursor
-
-  private func showOverflowMenuAtCursor() {
-    guard ensureAccessibility() else { return }
-
-    let menu = buildOverflowMenu()
-    let mouseLocation = NSEvent.mouseLocation
-
-    // Create a temporary invisible window at mouse location to anchor the menu
-    let tmpWindow = NSWindow(
-      contentRect: NSRect(x: mouseLocation.x - 1, y: mouseLocation.y - 1, width: 2, height: 2),
-      styleMask: [.borderless],
-      backing: .buffered,
-      defer: false
-    )
-    tmpWindow.level = .popUpMenu
-    tmpWindow.backgroundColor = .clear
-    tmpWindow.isOpaque = false
-    tmpWindow.orderFrontRegardless()
-
-    menu.popUp(positioning: nil, at: NSPoint(x: 1, y: 1), in: tmpWindow.contentView)
-
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-      tmpWindow.orderOut(nil)
-    }
-  }
-
   // MARK: - Menu Building
 
-  private func buildOverflowMenu() -> NSMenu {
-    let allExtras = getAllMenuBarExtras()
-
-    let rightEdge = notchRightEdge
-    let hiddenExtras = allExtras.filter {
-      $0.size.width > 0 && $0.size.height > 0 && $0.position.x < rightEdge
-    }
-    let visibleExtras = allExtras.filter {
-      $0.size.width > 0 && $0.size.height > 0 && $0.position.x >= rightEdge
-    }
+  func buildOverflowMenu(
+    extras: [MenuBarExtraInfo]? = nil,
+    boundary: CGFloat? = nil
+  ) -> NSMenu {
+    let allExtras = extras ?? getAllMenuBarExtras()
+    let resolvedBoundary = boundary ?? Self.currentBoundary().overflowThresholdX
+    let (hiddenExtras, visibleExtras) = MenuBarExtraClassifier.classify(allExtras, boundary: resolvedBoundary)
 
     let menu = NSMenu()
     menu.autoenablesItems = false
 
     // Title
-    let titleItem = NSMenuItem(title: "Notch Overflow  \u{2318}\u{21E7}B", action: nil, keyEquivalent: "")
+    let titleItem = NSMenuItem(title: "Notch Overflow".localized, action: nil, keyEquivalent: "")
     titleItem.isEnabled = false
     if #available(macOS 10.14, *) {
       titleItem.attributedTitle = NSAttributedString(
@@ -130,13 +150,13 @@ class NotchOverflowController: NSObject {
     // Hidden section
     if !hiddenExtras.isEmpty {
       let header = NSMenuItem(
-        title: "\u{26A0} Hidden Behind Notch (\(hiddenExtras.count))",
+        title: String(format: "Hidden Behind Notch (%d)".localized, hiddenExtras.count),
         action: nil, keyEquivalent: "")
       header.isEnabled = false
       menu.addItem(header)
       menu.addItem(NSMenuItem.separator())
 
-      for info in hiddenExtras.sorted(by: { $0.position.x > $1.position.x }) {
+      for info in hiddenExtras {
         menu.addItem(makeMenuItem(for: info, hidden: true))
       }
     }
@@ -145,13 +165,13 @@ class NotchOverflowController: NSObject {
     if !visibleExtras.isEmpty {
       if !hiddenExtras.isEmpty { menu.addItem(NSMenuItem.separator()) }
       let header = NSMenuItem(
-        title: "Visible (\(visibleExtras.count))",
+        title: String(format: "Visible (%d)".localized, visibleExtras.count),
         action: nil, keyEquivalent: "")
       header.isEnabled = false
       menu.addItem(header)
       menu.addItem(NSMenuItem.separator())
 
-      for info in visibleExtras.sorted(by: { $0.position.x > $1.position.x }) {
+      for info in visibleExtras {
         menu.addItem(makeMenuItem(for: info, hidden: false))
       }
     }
@@ -159,7 +179,7 @@ class NotchOverflowController: NSObject {
     // Empty state
     if hiddenExtras.isEmpty && visibleExtras.isEmpty {
       let emptyItem = NSMenuItem(
-        title: "No items found (grant Accessibility permission)",
+        title: "No items found (grant Accessibility permission)".localized,
         action: nil, keyEquivalent: "")
       emptyItem.isEnabled = false
       menu.addItem(emptyItem)
@@ -268,12 +288,11 @@ class NotchOverflowController: NSObject {
 private extension NSImage {
   func resizedForMenu(tinted: Bool = false) -> NSImage {
     let target = NSSize(width: 18, height: 18)
-    let img = NSImage(size: target)
-    img.lockFocus()
-    self.draw(in: NSRect(origin: .zero, size: target),
-              from: NSRect(origin: .zero, size: self.size),
-              operation: .sourceOver, fraction: tinted ? 0.5 : 1.0)
-    img.unlockFocus()
-    return img
+    return NSImage(size: target, flipped: false) { rect in
+      self.draw(in: rect,
+                from: NSRect(origin: .zero, size: self.size),
+                operation: .sourceOver, fraction: tinted ? 0.5 : 1.0)
+      return true
+    }
   }
 }

--- a/hidden/Features/NotchOverflow/NotchOverflowController.swift
+++ b/hidden/Features/NotchOverflow/NotchOverflowController.swift
@@ -134,26 +134,12 @@ class NotchOverflowController: NSObject {
     menu.autoenablesItems = false
 
     // Title
-    let titleItem = NSMenuItem(title: "Notch Overflow".localized, action: nil, keyEquivalent: "")
-    titleItem.isEnabled = false
-    if #available(macOS 10.14, *) {
-      titleItem.attributedTitle = NSAttributedString(
-        string: titleItem.title,
-        attributes: [
-          .font: NSFont.systemFont(ofSize: 12, weight: .bold),
-          .foregroundColor: NSColor.secondaryLabelColor
-        ])
-    }
-    menu.addItem(titleItem)
+    menu.addItem(makeSectionHeader(title: "Notch Overflow".localized, fontSize: 12))
     menu.addItem(NSMenuItem.separator())
 
     // Hidden section
     if !hiddenExtras.isEmpty {
-      let header = NSMenuItem(
-        title: String(format: "Hidden Behind Notch (%d)".localized, hiddenExtras.count),
-        action: nil, keyEquivalent: "")
-      header.isEnabled = false
-      menu.addItem(header)
+      menu.addItem(makeSectionHeader(title: String(format: "Hidden Behind Notch (%d)".localized, hiddenExtras.count)))
       menu.addItem(NSMenuItem.separator())
 
       for info in hiddenExtras {
@@ -164,11 +150,7 @@ class NotchOverflowController: NSObject {
     // Visible section
     if !visibleExtras.isEmpty {
       if !hiddenExtras.isEmpty { menu.addItem(NSMenuItem.separator()) }
-      let header = NSMenuItem(
-        title: String(format: "Visible (%d)".localized, visibleExtras.count),
-        action: nil, keyEquivalent: "")
-      header.isEnabled = false
-      menu.addItem(header)
+      menu.addItem(makeSectionHeader(title: String(format: "Visible (%d)".localized, visibleExtras.count)))
       menu.addItem(NSMenuItem.separator())
 
       for info in visibleExtras {
@@ -188,21 +170,35 @@ class NotchOverflowController: NSObject {
     return menu
   }
 
+  // Disabled, non-interactive label. Bold + labelColor (full contrast) rather
+  // than secondaryLabelColor/AppKit's default disabled-item dimming, which
+  // read poorly against a dark selection highlight.
+  private func makeSectionHeader(title: String, fontSize: CGFloat = 13) -> NSMenuItem {
+    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+    item.isEnabled = false
+    item.attributedTitle = NSAttributedString(
+      string: title,
+      attributes: [
+        .font: NSFont.systemFont(ofSize: fontSize, weight: .bold),
+        .foregroundColor: NSColor.labelColor
+      ])
+    return item
+  }
+
   private func makeMenuItem(for info: MenuBarExtraInfo, hidden: Bool = false) -> NSMenuItem {
     let item = NSMenuItem()
     let displayTitle = (info.title?.isEmpty == false) ? info.title! : info.appName
 
     if hidden {
-      if #available(macOS 10.14, *) {
-        item.attributedTitle = NSAttributedString(
-          string: displayTitle,
-          attributes: [
-            .font: NSFont.systemFont(ofSize: 13),
-            .foregroundColor: NSColor.systemOrange
-          ])
-      } else {
-        item.title = displayTitle
-      }
+      // Color alone isn't an accessible way to convey "hidden" (colorblind
+      // users get nothing from it, and systemOrange reads poorly against a
+      // dark selection highlight). A glyph + bold weight works in any theme.
+      item.attributedTitle = NSAttributedString(
+        string: "\u{26A0}\u{FE0F} \(displayTitle)",
+        attributes: [
+          .font: NSFont.boldSystemFont(ofSize: 13),
+          .foregroundColor: NSColor.labelColor
+        ])
     } else {
       item.title = displayTitle
     }

--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -53,6 +53,7 @@ class PreferencesViewController: NSViewController {
         updateData()
         loadHotkey()
         createTutorialView()
+        addNotchOverflowSection()
         NotificationCenter.default.addObserver(self, selector: #selector(updateData), name: .prefsChanged, object: nil)
     }
 
@@ -193,6 +194,33 @@ class PreferencesViewController: NSViewController {
     private func updateClearButton(_ globalKeybindPreference : GlobalKeybindPreferences?) {
         btnClear.isEnabled = globalKeybindPreference != nil
     }
+}
+
+//MARK: - Notch Overflow Section
+extension PreferencesViewController {
+
+    func addNotchOverflowSection() {
+        guard NotchOverflowController.hasNotch else { return }
+
+        // Add compact info below the tutorial area, anchored to statusBarStackView
+        let infoLabel = NSTextField(labelWithString:
+            "Notch Overflow:  \u{2318}\u{21E7}B  or  right-click \u{2039}  to access hidden icons")
+        infoLabel.font = NSFont.systemFont(ofSize: 10.5)
+        if #available(macOS 10.14, *) {
+            infoLabel.textColor = .secondaryLabelColor
+        }
+        infoLabel.alignment = .center
+        infoLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(infoLabel)
+
+        // Position centered, between tutorial text and Settings divider
+        // statusBarStackView is near the top; we go well below it
+        NSLayoutConstraint.activate([
+            infoLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            infoLabel.topAnchor.constraint(equalTo: statusBarStackView.bottomAnchor, constant: 78)
+        ])
+    }
+
 }
 
 //MARK: - Show tutorial

--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -36,7 +36,12 @@ class PreferencesViewController: NSViewController {
     
     @IBOutlet weak var btnClear: NSButton!
     @IBOutlet weak var btnShortcut: NSButton!
-    
+
+    // Not IB-managed: the notch overflow section is only relevant on notched
+    // Macs, so it's added programmatically rather than always present in the
+    // storyboard (see addNotchOverflowSection).
+    private var checkBoxNotchOverflow: NSButton?
+
     public var listening = false {
         didSet {
             let isHighlight = listening
@@ -163,6 +168,7 @@ class PreferencesViewController: NSViewController {
         checkBoxShowPreferences.state = Preferences.isShowPreference ? .on : .off
         checkBoxShowAlwaysHiddenSection.state = Preferences.alwaysHiddenSectionEnabled ? .on : .off
         timePopup.selectItem(at: SelectedSecond.secondToPossition(seconds: Preferences.numberOfSecondForAutoHide))
+        checkBoxNotchOverflow?.state = Preferences.notchOverflowEnabled ? .on : .off
     }
     
     private func loadHotkey() {
@@ -202,23 +208,28 @@ extension PreferencesViewController {
     func addNotchOverflowSection() {
         guard NotchOverflowController.hasNotch else { return }
 
-        // Add compact info below the tutorial area, anchored to statusBarStackView
-        let infoLabel = NSTextField(labelWithString:
-            "Notch Overflow:  \u{2318}\u{21E7}B  or  right-click \u{2039}  to access hidden icons")
-        infoLabel.font = NSFont.systemFont(ofSize: 10.5)
-        if #available(macOS 10.14, *) {
-            infoLabel.textColor = .secondaryLabelColor
-        }
-        infoLabel.alignment = .center
-        infoLabel.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addSubview(infoLabel)
+        // Reviewer feedback on #350: enabling Accessibility access for this
+        // feature should be an explicit, reversible user choice, not silent.
+        let checkbox = NSButton(
+            checkboxWithTitle: "Enable Notch Overflow (right-click \u{2039} to access hidden icons)".localized,
+            target: self,
+            action: #selector(notchOverflowCheckChanged(_:)))
+        checkbox.state = Preferences.notchOverflowEnabled ? .on : .off
+        checkbox.font = NSFont.systemFont(ofSize: 10.5)
+        checkbox.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(checkbox)
+        self.checkBoxNotchOverflow = checkbox
 
-        // Position centered, between tutorial text and Settings divider
-        // statusBarStackView is near the top; we go well below it
+        // Positioned centered, between tutorial text and Settings divider;
+        // statusBarStackView is near the top, so this sits well below it.
         NSLayoutConstraint.activate([
-            infoLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            infoLabel.topAnchor.constraint(equalTo: statusBarStackView.bottomAnchor, constant: 78)
+            checkbox.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            checkbox.topAnchor.constraint(equalTo: statusBarStackView.bottomAnchor, constant: 78)
         ])
+    }
+
+    @IBAction func notchOverflowCheckChanged(_ sender: NSButton) {
+        Preferences.notchOverflowEnabled = sender.state == .on
     }
 
 }

--- a/hidden/Features/Preferences/PreferencesViewController.swift
+++ b/hidden/Features/Preferences/PreferencesViewController.swift
@@ -37,10 +37,7 @@ class PreferencesViewController: NSViewController {
     @IBOutlet weak var btnClear: NSButton!
     @IBOutlet weak var btnShortcut: NSButton!
 
-    // Not IB-managed: the notch overflow section is only relevant on notched
-    // Macs, so it's added programmatically rather than always present in the
-    // storyboard (see addNotchOverflowSection).
-    private var checkBoxNotchOverflow: NSButton?
+    @IBOutlet weak var checkBoxNotchOverflow: NSButton!
 
     public var listening = false {
         didSet {
@@ -58,7 +55,10 @@ class PreferencesViewController: NSViewController {
         updateData()
         loadHotkey()
         createTutorialView()
-        addNotchOverflowSection()
+        // The row lives in the storyboard alongside the other Settings
+        // checkboxes; hide it on hardware where the feature can't apply.
+        // The containing stack view (detachesHiddenViews) reflows on its own.
+        checkBoxNotchOverflow.isHidden = !NotchOverflowController.hasNotch
         NotificationCenter.default.addObserver(self, selector: #selector(updateData), name: .prefsChanged, object: nil)
     }
 
@@ -168,7 +168,7 @@ class PreferencesViewController: NSViewController {
         checkBoxShowPreferences.state = Preferences.isShowPreference ? .on : .off
         checkBoxShowAlwaysHiddenSection.state = Preferences.alwaysHiddenSectionEnabled ? .on : .off
         timePopup.selectItem(at: SelectedSecond.secondToPossition(seconds: Preferences.numberOfSecondForAutoHide))
-        checkBoxNotchOverflow?.state = Preferences.notchOverflowEnabled ? .on : .off
+        checkBoxNotchOverflow.state = Preferences.notchOverflowEnabled ? .on : .off
     }
     
     private func loadHotkey() {
@@ -204,29 +204,6 @@ class PreferencesViewController: NSViewController {
 
 //MARK: - Notch Overflow Section
 extension PreferencesViewController {
-
-    func addNotchOverflowSection() {
-        guard NotchOverflowController.hasNotch else { return }
-
-        // Reviewer feedback on #350: enabling Accessibility access for this
-        // feature should be an explicit, reversible user choice, not silent.
-        let checkbox = NSButton(
-            checkboxWithTitle: "Enable Notch Overflow (right-click \u{2039} to access hidden icons)".localized,
-            target: self,
-            action: #selector(notchOverflowCheckChanged(_:)))
-        checkbox.state = Preferences.notchOverflowEnabled ? .on : .off
-        checkbox.font = NSFont.systemFont(ofSize: 10.5)
-        checkbox.translatesAutoresizingMaskIntoConstraints = false
-        self.view.addSubview(checkbox)
-        self.checkBoxNotchOverflow = checkbox
-
-        // Positioned centered, between tutorial text and Settings divider;
-        // statusBarStackView is near the top, so this sits well below it.
-        NSLayoutConstraint.activate([
-            checkbox.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            checkbox.topAnchor.constraint(equalTo: statusBarStackView.bottomAnchor, constant: 78)
-        ])
-    }
 
     @IBAction func notchOverflowCheckChanged(_ sender: NSButton) {
         Preferences.notchOverflowEnabled = sender.state == .on

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -9,15 +9,18 @@
 import AppKit
 
 class StatusBarController {
-    
+
     //MARK: - Variables
     private var timer:Timer? = nil
-    
+
     //MARK: - BarItems
-        
+
     private let btnExpandCollapse = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let btnSeparate = NSStatusBar.system.statusItem(withLength: 1)
     private var btnAlwaysHidden:NSStatusItem? = nil
+
+    //MARK: - Notch Overflow
+    private(set) var notchOverflowController = NotchOverflowController()
     
     private var btnHiddenLength: CGFloat = 20
     private var btnHiddenCollapseLength: CGFloat = 2000
@@ -113,6 +116,21 @@ class StatusBarController {
         
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotchOverflowToggle), name: .notchOverflowToggle, object: nil)
+    }
+
+    /// Called from AppDelegate after defaults are registered
+    func setupNotchOverflow() {
+        notchOverflowController.setup()
+    }
+
+    @objc private func handleNotchOverflowToggle() {
+        if Preferences.notchOverflowEnabled {
+            notchOverflowController.setup()
+        } else {
+            notchOverflowController.teardown()
+        }
     }
     
     deinit {
@@ -207,7 +225,7 @@ class StatusBarController {
 
             let isOptionKeyPressed = event.modifierFlags.contains(NSEvent.ModifierFlags.option)
 
-            if event.type == NSEvent.EventType.leftMouseUp && !isOptionKeyPressed{
+            if event.type == NSEvent.EventType.leftMouseUp && !isOptionKeyPressed {
                 self.expandCollapseIfNeeded()
             } else if event.type == NSEvent.EventType.rightMouseUp && !isOptionKeyPressed {
                 // Right-click opens the same context menu the separator has (#356),
@@ -344,11 +362,19 @@ class StatusBarController {
     
     private func getContextMenu() -> NSMenu {
         let menu = NSMenu()
-        
+
+        // Notch overflow menu item (only on notch Macs)
+        if NotchOverflowController.hasNotch {
+            let overflowItem = NSMenuItem(title: "Show Notch Items (\u{2318}\u{21E7}B)", action: #selector(showNotchOverflow), keyEquivalent: "")
+            overflowItem.target = self
+            menu.addItem(overflowItem)
+            menu.addItem(NSMenuItem.separator())
+        }
+
         let prefItem = NSMenuItem(title: "Preferences...".localized, action: #selector(openPreferenceViewControllerIfNeeded), keyEquivalent: "P")
         prefItem.target = self
         menu.addItem(prefItem)
-        
+
         let toggleAutoHideItem = NSMenuItem(title: "Toggle Auto Collapse".localized, action: #selector(toggleAutoHide), keyEquivalent: "t")
         toggleAutoHideItem.target = self
         toggleAutoHideItem.tag = 1
@@ -377,6 +403,10 @@ class StatusBarController {
     
     @objc func openPreferenceViewControllerIfNeeded() {
         Util.showPrefWindow()
+    }
+
+    @objc func showNotchOverflow() {
+        notchOverflowController.showOverflowMenuFromSeparator(near: btnExpandCollapse)
     }
     
     @objc func toggleAutoHide() {

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -110,21 +110,13 @@ class StatusBarController {
         setupAlwayHideStatusBar()
         setupHoverToExpandIfEnabled()
         NotificationCenter.default.addObserver(self, selector: #selector(handleScreenParametersChanged), name: NSApplication.didChangeScreenParametersNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateAutoHide), name: .prefsChanged, object: nil)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             self?.collapseMenuBar()
         }
-        
+
         if Preferences.areSeparatorsHidden {hideSeparators()}
         autoCollapseIfNeeded()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(handleNotchOverflowToggle), name: .notchOverflowToggle, object: nil)
-    }
-
-    // Rebuilds the separator's menu so the "Show Notch Items" entry appears
-    // or disappears immediately when the preference is toggled, rather than
-    // only taking effect after the next relaunch.
-    @objc private func handleNotchOverflowToggle() {
-        btnSeparate.menu = getContextMenu()
     }
 
     deinit {
@@ -196,12 +188,11 @@ class StatusBarController {
     private func setupUI() {
         if let button = btnSeparate.button {
             button.image = self.imgIconLine
+            button.target = self
+            button.action = #selector(self.showContextMenuFromSeparator(sender:))
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
-        let menu = self.getContextMenu()
-        btnSeparate.menu = menu
 
-        updateAutoCollapseMenuTitle()
-        
         if let button = btnExpandCollapse.button {
             button.image = Assets.collapseImage
             button.target = self
@@ -233,9 +224,37 @@ class StatusBarController {
         }
     }
 
+    @objc private func showContextMenuFromSeparator(sender: NSStatusBarButton) {
+        showContextMenu(from: sender)
+    }
+
+    // Builds a brand-new NSMenu for every presentation rather than mutating
+    // a reused one via a delegate callback (content changes on an
+    // already-displayed-before NSMenu instance could leave its backing
+    // window at a stale size until an unrelated redraw corrected it).
+    //
+    // Uses popUp(at:), not performClick(nil): this method is ITSELF called
+    // from this same button's own action handler (a real click already in
+    // progress). performClick(nil) here re-entered NSStatusBarButtonCell's
+    // own sendAction dispatch, recursing into this handler again and
+    // stack-overflowing (SIGSEGV, confirmed via crash report) - unlike
+    // NotchOverflowController.showOverflowMenuFromSeparator, which is safe
+    // because it's invoked from a *different* control's action (a menu
+    // item), not from btnExpandCollapse's own click handler.
+    //
+    // Previously anchored at `button.bounds.maxY + 5` (5pt above the
+    // button's TOP edge). For a menu-bar item that's essentially the
+    // physical top of the screen, so once "Show Notch Items" made the menu
+    // one row taller, that top row landed in the sliver above the visible
+    // screen and AppKit showed its standard "content doesn't fit here"
+    // scroll-indicator caret instead of rendering it - hovering over the
+    // indicator scrolled the whole menu into view, which is what looked
+    // like the item "appearing on hover". Anchoring at the button's BOTTOM
+    // edge instead (y: 0, not bounds.maxY) keeps the menu entirely within
+    // on-screen space, growing downward from below the button.
     private func showContextMenu(from button: NSStatusBarButton) {
-        guard let menu = btnSeparate.menu else { return }
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.maxY + 5), in: button)
+        let menu = getContextMenu()
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: button)
     }
     
     func showHideSeparatorsAndAlwayHideArea() {
@@ -354,6 +373,9 @@ class StatusBarController {
         }
     }
     
+    // Built fresh on every call (see showContextMenu(from:)), so every field
+    // below reflects state as of THIS presentation - no separate "patch the
+    // title after the fact" step is needed for the auto-collapse item.
     private func getContextMenu() -> NSMenu {
         let menu = NSMenu()
 
@@ -369,29 +391,18 @@ class StatusBarController {
         prefItem.target = self
         menu.addItem(prefItem)
 
-        let toggleAutoHideItem = NSMenuItem(title: "Toggle Auto Collapse".localized, action: #selector(toggleAutoHide), keyEquivalent: "t")
+        let toggleAutoHideTitle = Preferences.isAutoHide ? "Disable Auto Collapse" : "Enable Auto Collapse"
+        let toggleAutoHideItem = NSMenuItem(title: toggleAutoHideTitle.localized, action: #selector(toggleAutoHide), keyEquivalent: "t")
         toggleAutoHideItem.target = self
-        toggleAutoHideItem.tag = 1
-        NotificationCenter.default.addObserver(self, selector: #selector(updateAutoHide), name: .prefsChanged, object: nil)
         menu.addItem(toggleAutoHideItem)
 
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit".localized, action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
-        
+
         return menu
     }
-    
-    private func updateAutoCollapseMenuTitle() {
-        guard let toggleAutoHideItem = btnSeparate.menu?.item(withTag: 1) else { return }
-        if Preferences.isAutoHide {
-            toggleAutoHideItem.title = "Disable Auto Collapse".localized
-        } else {
-            toggleAutoHideItem.title = "Enable Auto Collapse".localized
-        }
-    }
-    
+
     @objc func updateAutoHide() {
-        updateAutoCollapseMenuTitle()
         autoCollapseIfNeeded()
     }
     

--- a/hidden/Features/StatusBar/StatusBarController.swift
+++ b/hidden/Features/StatusBar/StatusBarController.swift
@@ -20,7 +20,7 @@ class StatusBarController {
     private var btnAlwaysHidden:NSStatusItem? = nil
 
     //MARK: - Notch Overflow
-    private(set) var notchOverflowController = NotchOverflowController()
+    private var notchOverflowController = NotchOverflowController()
     
     private var btnHiddenLength: CGFloat = 20
     private var btnHiddenCollapseLength: CGFloat = 2000
@@ -120,19 +120,13 @@ class StatusBarController {
         NotificationCenter.default.addObserver(self, selector: #selector(handleNotchOverflowToggle), name: .notchOverflowToggle, object: nil)
     }
 
-    /// Called from AppDelegate after defaults are registered
-    func setupNotchOverflow() {
-        notchOverflowController.setup()
+    // Rebuilds the separator's menu so the "Show Notch Items" entry appears
+    // or disappears immediately when the preference is toggled, rather than
+    // only taking effect after the next relaunch.
+    @objc private func handleNotchOverflowToggle() {
+        btnSeparate.menu = getContextMenu()
     }
 
-    @objc private func handleNotchOverflowToggle() {
-        if Preferences.notchOverflowEnabled {
-            notchOverflowController.setup()
-        } else {
-            notchOverflowController.teardown()
-        }
-    }
-    
     deinit {
         NotificationCenter.default.removeObserver(self)
         hoverDwellTimer?.invalidate()
@@ -363,9 +357,9 @@ class StatusBarController {
     private func getContextMenu() -> NSMenu {
         let menu = NSMenu()
 
-        // Notch overflow menu item (only on notch Macs)
-        if NotchOverflowController.hasNotch {
-            let overflowItem = NSMenuItem(title: "Show Notch Items (\u{2318}\u{21E7}B)", action: #selector(showNotchOverflow), keyEquivalent: "")
+        // Notch overflow menu item (only on notch Macs, and only when enabled)
+        if NotchOverflowController.hasNotch && Preferences.notchOverflowEnabled {
+            let overflowItem = NSMenuItem(title: "Show Notch Items".localized, action: #selector(showNotchOverflow), keyEquivalent: "")
             overflowItem.target = self
             menu.addItem(overflowItem)
             menu.addItem(NSMenuItem.separator())

--- a/hidden/en.lproj/Localizable.strings
+++ b/hidden/en.lproj/Localizable.strings
@@ -12,6 +12,12 @@
 "Disable Auto Collapse" = "Disable Auto Collapse";
 "Quit" = "Quit";
 "Set Shortcut" = "Set Shortcut";
+"Show Notch Items" = "Show Notch Items";
+"Notch Overflow" = "Notch Overflow";
+"Hidden Behind Notch (%d)" = "Hidden Behind Notch (%d)";
+"Visible (%d)" = "Visible (%d)";
+"No items found (grant Accessibility permission)" = "No items found (grant Accessibility permission)";
+"Enable Notch Overflow (right-click ‹ to access hidden icons)" = "Enable Notch Overflow (right-click ‹ to access hidden icons)";
 "Tutorial text" = "
 Use the always hidden feature to keep your icons tidy. Here's how to set it
 Steps to enable:


### PR DESCRIPTION
## Summary

Builds on #350 by @mehmetnadir — same feature (an overflow menu to reach
menu-bar icons macOS silently drops behind the camera notch), rebased onto
current `develop` and with every item from @laveez's review addressed.
#350 went quiet for ~5 months with no author response to the review, so
this continues it as a new PR rather than waiting further; #350 should
probably be closed in favor of this one. Original authorship is preserved
via cherry-pick (see first commit).

This is one of the "notch overlap" candidate implementations named in the
managed-overflow epic (#366) — a smaller, immediately mergeable fix, not a
replacement for that larger redesign.

Manually verified end-to-end on real notched hardware.

## What changed since #350

Addressing @laveez's review comments directly:

- **Notch boundary**: now derived from `NSScreen.auxiliaryTopRightArea`
  instead of `screen.frame.width / 8`, which produced the wrong boundary on
  screens other than the one it was tuned against.
- **Global hotkey**: removed the hardcoded ⌘⇧B (conflicts with Chrome's
  bookmarks-bar shortcut) rather than rebuilding it behind a second
  configurable-hotkey system — the right-click "Show Notch Items" entry
  already covers reachability, so a second hotkey-recorder UI wasn't
  justified for this PR.
- **Right-click behavior**: no longer shows a separate duplicate menu for
  all users. The notch item is folded into the same context menu
  right-click already opens (#356), so non-notch users see zero behavior
  change. The menu is built fresh on every open (`getContextMenu()`
  called from `showContextMenu(from:)`, not a menu built once and reused)
  so "Show Notch Items" and the auto-collapse toggle title always reflect
  current state, and it's anchored at the button's bottom edge so it
  renders entirely within on-screen space regardless of item count.
- **Deprecated API**: replaced `NSImage` `lockFocus()`/`unlockFocus()` with
  the `size:flipped:drawingHandler:` initializer.
- **Localization**: user-facing strings now go through `.localized`.
  Source strings are added to `en.lproj`; the other 8 locales will need
  community translation for these new keys (I'm not a speaker of any of
  them and didn't want to guess).
- **Enable/disable**: @laveez asked "should we have a way to enable/disable
  this feature manually?" — #350 added a `notchOverflowEnabled` pref key
  but never wired it into any UI or actual gating. This PR adds a real
  Preferences checkbox, placed in the Settings panel using the same
  storyboard-outlet mechanism as the other checkboxes (not floating
  elsewhere in the window).
- **Hidden-item indicator**: changed from an orange color tint to a
  `⚠️` glyph + bold weight at the normal label color. Color alone isn't an
  accessible way to convey "hidden" (colorblind users get nothing from it),
  and the orange read poorly against a dark selection highlight in manual
  testing. Section headers ("Notch Overflow", "Hidden Behind Notch (N)",
  "Visible (N)") were also bumped from a dim secondary/default-disabled
  style to full-contrast bold for the same legibility reason.

## Approaches that don't work here (kept for future reference)

Two other ways of keeping the context menu's content fresh were tried
during development and discarded — noting them so nobody spends time
re-trying either:

- **`NSMenuDelegate.menuNeedsUpdate(_:)`**, rebuilding the menu's contents
  right before display — content-mutating an already-displayed-before
  `NSMenu` instance while its own tracking loop is active produced a stray
  `^` caret glyph on first paint instead of the real top item.
- **`button.menu = menu; button.performClick(nil)`** (the pattern
  `NotchOverflowController.showOverflowMenuFromSeparator` uses safely
  elsewhere in this same file) — crashes when called from
  `showContextMenu(from:)`: `SIGSEGV`/stack overflow in
  `NSStatusBarButtonCell._sendActionFrom:`, because that method is called
  from *within* the button's own click-action handler, so `performClick`
  recursively re-enters it. `showOverflowMenuFromSeparator` is safe only
  because it's invoked from a *different* control's action (a menu item).

Both are documented inline at `StatusBarController.showContextMenu(from:)`.

## Test evidence

This project had no test target at all before this PR. Added `HiddenTests`
(wired into the shared scheme; `xcodebuild test -scheme "Hidden Bar"` runs
it), with 15 tests covering the logic extracted specifically to make it
testable:

- `NotchGeometryTests` (4): no-notch detection, notch detection, boundary
  sourced from `auxiliaryTopRightArea`, fallback when a notch is reported
  without an aux rect — this last one regression-guards the exact
  width-fraction bug flagged in review.
- `MenuBarExtraClassifierTests` (4): hidden/visible bucketing, zero-size
  extras excluded, closest-to-boundary-first ordering.
- `NotchOverflowMenuBuilderTests` (5): empty state, section header counts,
  section headers use full-contrast label color, empty-title fallback to
  app name, hidden-item distinguished by glyph and weight (not color
  alone).
- `NotchOverflowPreferencesTests` (2): fresh-install default, persistence
  round-trip.

```
Test Suite 'All tests' passed
** TEST SUCCEEDED **
```

Not unit-tested, named explicitly rather than faked: live `AXUIElement`
enumeration against real running apps, and real notch/menu geometry on
physical hardware (menu positioning specifically needed a real,
interactive menu-tracking session on real hardware — not reproducible in a
headless test).

## Test plan

Manually verified on real notched hardware (MacBook Pro, physical camera
notch):

- [x] Right-click the separator and the collapse/expand button — "Show
      Notch Items" renders immediately, no hover needed
- [x] Hidden items show the `⚠️` glyph in bold; visible items don't
- [x] Clicking a hidden item activates the real menu-bar extra underneath
- [x] Accessibility permission prompt appears on first use, as expected
- [x] Preferences checkbox lives in the Settings panel (not floating
      elsewhere), toggling it removes the "Show Notch Items" entry
- [x] Automated: `xcodebuild test -scheme "Hidden Bar"` — 15/15 passing
- [x] Build succeeds with code signing disabled (no Developer ID available
      in this environment)
- [ ] Not verified: behavior on a non-notch Mac (no such hardware available
      in this environment; code-reviewed to be a no-op via the same
      `hasNotch` gate used everywhere else in the file)
